### PR TITLE
Fix toPlace() function

### DIFF
--- a/scripts/mk.js
+++ b/scripts/mk.js
@@ -27886,14 +27886,14 @@ function toLanguage(english, french) {
 function toPlace(place) {
 	var term;
 	if (language) {
-		switch (place) {
-		case 1 :
+		switch (place.toString().charAt(place.toString().length - 1)) {
+		case "1" :
 			term = "st";
 			break;
-		case 2 :
+		case "2" :
 			term = "nd";
 			break;
-		case 3 :
+		case "3" :
 			term = "rd";
 			break;
 		default :


### PR DESCRIPTION
toPlace() previously only worked if you had first, second, or third. It automatically replaced any other number's suffix with "th" instead. Note that this still needs to be polished a little bit since "11" would become "11st", "12" would become "12nd", and "13" would become "13rd". These are the only three issues with the system I can think of from the top of my head, but it is far better than how it previously worked with replacing all numbers, four through infinity, with the suffix "th".