### PR TITLE
Chat box movement fix on Firefox

### DIFF
--- a/styles/online.css
+++ b/styles/online.css
@@ -396,6 +396,7 @@
 	font-size: 0.8em;
 	padding: 0px 0px 2px 7px;
 	cursor: move;
+	user-select: none;
 }
 .chatbar .chatbullet {
 	position: relative;


### PR DESCRIPTION
Fixes a bug on Firefox clients that caused text from the webpage to be selected when you move a chat box, which causes the text to flicker blue.

To reproduce the bug, open Firefox, log in to your account, then go to "Members", then click on any of them, and open a chat, then try to move it. The text in the background will start flickering blue due to it trying to get selected.