### PR TITLE
Notification text overflow fix

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -180,7 +180,8 @@ nav {
 	width: 100%;
 	color: #008;
 	text-decoration: none;
-	height: 60px;
+	min-height: 60px;
+	height: min-content;
 	overflow: hidden;
 	padding: 0;
 }


### PR DESCRIPTION
Fixes an oversight that i saw a lot in my notifications feed

Basically, when a notification content is too long, it overflows like this, which causes the rest of the notification to be unreadable:
![image](https://github.com/tmalahie/mkpc/assets/81191621/a6c376ff-be00-42fd-a633-9b20f08a45b4)

So i came up with a simple CSS fix to make it so that it keeps its original 60px height, but gives itself more height when it overflows, like this:
![image](https://github.com/tmalahie/mkpc/assets/81191621/9956a7ff-d183-4b39-8687-d1b003a747e5)
