### PR TITLE
Add option to disable decor minimap

### DIFF
--- a/php/api/getDecorData.php
+++ b/php/api/getDecorData.php
@@ -11,7 +11,7 @@ if (isset($_GET['id'])) {
             'name' => $decor['name'],
             'hd' => $decorSrcs['hd'],
             'ld' => $decorSrcs['ld'],
-            'map' => $decorSrcs['map']
+            'map' => decor_has_no_map_icon($decor) ? '' : $decorSrcs['map']
         );
         if (isset($_GET['full'])) {
             $decorType = $decor['type'];
@@ -40,7 +40,7 @@ if (isset($_GET['id'])) {
                         'id' => $decorExtra['id'],
                         'hd' => $decorExtraSrcs['hd'],
                         'ld' => $decorExtraSrcs['ld'],
-                        'map' => $decorExtraSrcs['map'],
+                        'map' => decor_has_no_map_icon($decorExtra) ? '' : $decorExtraSrcs['map'],
                         'size' => get_decor_sizes($decorExtra),
                         'original_size' => decor_sprite_sizes($decorExtra['type'],default_decor_sprite_src($decorExtra['type']))
                     );

--- a/php/includes/utils-decors.php
+++ b/php/includes/utils-decors.php
@@ -165,6 +165,11 @@ function compute_decor_sizes($type, $w,$h) {
     }
     return $res;
 }
+function decor_has_no_map_icon(&$decor) {
+    if (empty($decor['options'])) return false;
+    $options = json_decode($decor['options'], true);
+    return !empty($options['no_map_icon']);
+}
 function generate_decor_sprite_src($id) {
 	return 'dc-'.uniqid().'-'.$id;
 }

--- a/php/pages/coursepreview.php
+++ b/php/pages/coursepreview.php
@@ -67,7 +67,9 @@ if (isset($id)) {
 						$customDecor = $decorExtra->{$type}->custom;
 						$decorId = intval($customDecor->id);
 						$actualType = $customDecor->type;
-						if ($customData = mysql_fetch_array(mysql_query('SELECT sprites FROM mkdecors WHERE id='. $decorId))) {
+						if ($customData = mysql_fetch_array(mysql_query('SELECT sprites,options FROM mkdecors WHERE id='. $decorId))) {
+							if (decor_has_no_map_icon($customData))
+								continue;
 							$decorSrcs = decor_sprite_srcs($customData['sprites']);
 							$decorImg = @imagecreatefrompng($decorSrcs['ldir'].$decorSrcs['map']);
 						}
@@ -88,8 +90,8 @@ if (isset($id)) {
 							foreach ($decorsData as $decorData) {
 								if ('assets/' === substr($actualType, 0,7)) {
 									if (isset($decorData[2]) && isset($decorData[3])) {
-										$rW = $decorData[2];
-										$rH = $decorData[3];
+										$rW = round($decorData[2]);
+										$rH = round($decorData[3]);
 										if (isset($decorData[4])) {
 											$rX = round($rW*$decorData[4][0]);
 											$rY = round($rH*$decorData[4][1]);

--- a/php/pages/decorOptions.php
+++ b/php/pages/decorOptions.php
@@ -58,7 +58,7 @@ include('../includes/o_online.php');
 		<a class="advanced-option option-map" href="<?php echo $hasWriteGrants ? 'decorSprite.php?id='.urlencode($_GET['id']).$collabSuffix : 'javascript:void(0)'; ?>&amp;map">
 			<div class="option-bg">
 				<img src="images/maps/map3.png" alt="Map" />
-				<img id="ic-decor-preview" src="<?php echo $spriteSrcs['map']; ?>" alt="Decor" style="width:<?php echo round(12*$sizeRatio); ?>px" />
+				<img id="ic-decor-preview" src="<?php echo $spriteSrcs['map']; ?>" alt="Decor" style="width:<?php echo round(12*$sizeRatio); ?>px<?php if (decor_has_no_map_icon($decor)) echo ';visibility:hidden'; ?>" />
 				<div id="hitbox-preview"></div>
 			</div>
 			<div class="option-label"><?php

--- a/php/pages/decorProperties.php
+++ b/php/pages/decorProperties.php
@@ -2,20 +2,26 @@
 if (isset($_GET['id'])) {
     $decorId = intval($_GET['id']);
     $decorOptions = array('hitbox', 'spin', 'unbreaking', 'breaking');
+    $rawItems = isset($_POST['items']) ? $_POST['items'] : '';
+    include('../includes/initdb.php');
+    include('../includes/getId.php');
     $newOptions = array();
+    if ($row = mysql_fetch_array(mysql_query('SELECT options FROM `mkdecors` WHERE id="'. $decorId .'" AND identifiant="'. $identifiants[0] .'"'))) {
+        if ($row['options'])
+            $newOptions = json_decode($row['options'], true) ?: array();
+    }
+    foreach ($decorOptions as $option)
+        unset($newOptions[$option]);
+    unset($newOptions['items'], $newOptions['hitboxW']);
     foreach ($decorOptions as $option) {
         if (isset($_POST[$option]) && in_array($_POST[$option], array('0','1')))
             $newOptions[$option] = intval($_POST[$option]);
     }
-    if (!empty($_POST['items']))
-        $newOptions['items'] = json_decode($_POST['items']);
+    if (!empty($rawItems))
+        $newOptions['items'] = json_decode($rawItems);
     if (isset($_POST['hitbox-cb']) && isset($_POST['hitboxW']))
         $newOptions['hitboxW'] = intval($_POST['hitboxW']);
-    include('../includes/initdb.php');
-    include('../includes/getId.php');
-    $newOptionsJson = '';
-    if (!empty($newOptions))
-        $newOptionsJson = json_encode($newOptions);
+    $newOptionsJson = !empty($newOptions) ? json_encode($newOptions) : '';
     mysql_query('UPDATE `mkdecors` SET options="'. mysql_real_escape_string($newOptionsJson) .'" WHERE id="'. $decorId .'" AND identifiant="'. $identifiants[0] .'"');
     mysql_close();
     header('location: decorOptions.php?id='. $decorId);

--- a/php/pages/decorSprite.php
+++ b/php/pages/decorSprite.php
@@ -167,23 +167,37 @@ var spriteSrc = "<?php echo $spriteSrc; ?>", spriteW = <?php echo $spriteW; ?>, 
 			<?php
 		}
 		else {
-			?>
+			$noMapIcon = decor_has_no_map_icon($decor);
+			if (!$noMapIcon) { ?>
 			<div>
 				<input type="file" required="required" name="sprites" />
 				<button type="submit"><?php echo $language ? 'Send':'Valider'; ?></button>
 			</div>
 			<?php
-			if ($hasTransparency || ($spriteSrc !== $spriteSrcs['ld'])) {
-				?>
-				<div id="decor-current-img-preview">
-				<?php echo $language ? 'Current image:':'Image actuelle :'; ?>&nbsp;<img src="<?php echo $spriteSrc; ?>" alt="Image" class="current-sprite" />
+			}
+			?>
+			<div id="decor-current-img-preview">
+			<?php echo $language ? 'Current image:':'Image actuelle :'; ?>&nbsp;
+			<?php if ($noMapIcon): ?>
+				<em><?php echo $language ? 'None':'Aucune'; ?></em>
+			<?php elseif ($hasTransparency || ($spriteSrc !== $spriteSrcs['ld'])): ?>
+				<img src="<?php echo $spriteSrc; ?>" alt="Image" class="current-sprite" />
 				<?php
 				if ($spriteSrc != $spriteSrcs['ld'])
 					echo '&nbsp;<a href="delDecorSprite.php?id='. $decorId .'&amp;'. $type . htmlspecialchars($collabSuffix) .'" onclick="return confirm(\''. ($language ? "Go back to original image?":"Revenir à l\'image d\'origine ?") .'\')">['. ($language ? 'Reset':'Réinitialiser') .']</a>';
 				?>
-				</div>
-				<?php
-			}
+			<?php else: ?>
+				<em><?php echo $language ? 'Default':'Défaut'; ?></em>
+			<?php endif; ?>
+			</div>
+			<div id="map-icon-toggle">
+			<?php if ($noMapIcon): ?>
+				<a class="map-icon-enable" href="toggleDecorMapIcon.php?id=<?php echo $decorId . htmlspecialchars($collabSuffix); ?>&amp;enable"><?php echo $language ? 'Re-enable minimap icon':'Réactiver l\'icône de la mini-map'; ?></a>
+			<?php else: ?>
+				<a class="map-icon-disable" href="toggleDecorMapIcon.php?id=<?php echo $decorId . htmlspecialchars($collabSuffix); ?>" onclick="return confirm('<?php echo addslashes($language ? 'The decor icon will no longer appear on the minimap. Confirm?' : "L'icone du décor n'apparaitra plus sur la minimap. Confirmer ?"); ?>')"><?php echo $language ? 'Disable minimap icon':'Désactiver l\'icône de la mini-map'; ?></a>
+			<?php endif; ?>
+			</div>
+			<?php
 		}
 		?>
 		</form>

--- a/php/pages/racepreview.php
+++ b/php/pages/racepreview.php
@@ -67,7 +67,9 @@ if (isset($id)) {
 						$customDecor = $decorExtra->{$type}->custom;
 						$decorId = intval($customDecor->id);
 						$actualType = $customDecor->type;
-						if ($customData = mysql_fetch_array(mysql_query('SELECT sprites FROM mkdecors WHERE id='. $decorId))) {
+						if ($customData = mysql_fetch_array(mysql_query('SELECT sprites,options FROM mkdecors WHERE id='. $decorId))) {
+							if (decor_has_no_map_icon($customData))
+								continue;
 							$decorSrcs = decor_sprite_srcs($customData['sprites']);
 							$decorImg = @imagecreatefrompng($decorSrcs['ldir'].$decorSrcs['map']);
 						}

--- a/php/pages/toggleDecorMapIcon.php
+++ b/php/pages/toggleDecorMapIcon.php
@@ -1,0 +1,35 @@
+<?php
+if (isset($_GET['id'])) {
+	$decorId = intval($_GET['id']);
+	include('../includes/initdb.php');
+	include('../includes/getId.php');
+	require_once('../includes/collabUtils.php');
+	$collabSuffix = '';
+	$hasWriteGrants = false;
+	if ($decor = mysql_fetch_array(mysql_query('SELECT * FROM `mkdecors` WHERE id="'. $decorId .'"'))) {
+		if ($decor['identifiant'] == $identifiants[0]) {
+			$hasWriteGrants = true;
+		}
+		else {
+			$collab = getCollabLinkFromQuery('mkdecors', $decor['extra_parent_id'] ?? $decorId);
+			$hasWriteGrants = isset($collab['rights']['edit']);
+			if ($collab) $collabSuffix = '&collab='. $collab['key'];
+		}
+		if ($hasWriteGrants) {
+			require_once('../includes/utils-decors.php');
+			$options = $decor['options'] ? json_decode($decor['options'], true) : array();
+			if (isset($_GET['enable']))
+				unset($options['no_map_icon']);
+			else
+				$options['no_map_icon'] = 1;
+			$newOptionsJson = !empty($options) ? json_encode($options) : '';
+			mysql_query('UPDATE `mkdecors` SET options="'. mysql_real_escape_string($newOptionsJson) .'" WHERE id="'. $decorId .'"');
+		}
+	}
+	mysql_close();
+	if (isset($_GET['enable']))
+		header('location: decorSprite.php?id='. $decorId .'&map'. $collabSuffix);
+	else
+		header('location: decorOptions.php?id='. $decorId . $collabSuffix);
+}
+?>

--- a/scripts/mk.js
+++ b/scripts/mk.js
@@ -991,7 +991,10 @@ function setPlanPos(frameState, lMap) {
 							img.src = "images/map_icons/empty.png";
 							(function(img,type) {
 								getCustomDecorData(customData, function(res) {
-									img.src = res.map;
+									if (res.map)
+										img.src = res.map;
+									else
+										img.style.display = "none";
 									var newW, newH;
 									switch (type) {
 									case "flippers":
@@ -1142,7 +1145,15 @@ function setPlanPos(frameState, lMap) {
 								syncObjects(iPlanDecor[type],frameDecorType,type, tObjWidth,iPlanCtn);
 								for (var i=0;i<iPlanDecor[type].length;i++) {
 									var iDecor = iPlanDecor[type][i];
-									iDecor.src = res.map;
+									if (res.map) {
+										if (iDecor.src === '')
+											iDecor.style.display = "";
+										iDecor.src = res.map;
+									}
+									else {
+										iDecor.removeAttribute("src");
+										iDecor.style.display = "none";
+									}
 									iDecor.style.width = tObjWidth +"px";
 								}
 							});
@@ -11009,13 +11020,29 @@ function initCustomDecorSprites(self, lMap) {
 		for (var i=self.linkedSprite.start;i<self.linkedSprite.end;i++) {
 			var iDecor = oPlanDecor[linkedType] && oPlanDecor[linkedType][i];
 			if (iDecor) {
-				iDecor.src = linkedData.map;
+				if (linkedData.map) {
+					if (iDecor.src === '')
+						iDecor.style.display = "";
+					iDecor.src = linkedData.map;
+				}
+				else if (iDecor.src) {
+					iDecor.removeAttribute("src");
+					iDecor.style.display = "none";
+				}
 				iDecor.style.width = tObjWidth +"px";
 			}
 
 			iDecor = oPlanDecor2[linkedType] && oPlanDecor2[linkedType][i];
 			if (iDecor) {
-				iDecor.src = linkedData.map;
+				if (linkedData.map) {
+					if (iDecor.src === '')
+						iDecor.style.display = "";
+					iDecor.src = linkedData.map;
+				}
+				else if (iDecor.src) {
+					iDecor.removeAttribute("src");
+					iDecor.style.display = "none";
+				}
 				iDecor.style.width = tObjWidth2 +"px";
 			}
 		}

--- a/scripts/mk.js
+++ b/scripts/mk.js
@@ -1146,8 +1146,7 @@ function setPlanPos(frameState, lMap) {
 								for (var i=0;i<iPlanDecor[type].length;i++) {
 									var iDecor = iPlanDecor[type][i];
 									if (res.map) {
-										if (iDecor.src === '')
-											iDecor.style.display = "";
+										iDecor.style.display = "";
 										iDecor.src = res.map;
 									}
 									else {
@@ -11021,8 +11020,7 @@ function initCustomDecorSprites(self, lMap) {
 			var iDecor = oPlanDecor[linkedType] && oPlanDecor[linkedType][i];
 			if (iDecor) {
 				if (linkedData.map) {
-					if (iDecor.src === '')
-						iDecor.style.display = "";
+					iDecor.style.display = "";
 					iDecor.src = linkedData.map;
 				}
 				else if (iDecor.src) {
@@ -11035,8 +11033,7 @@ function initCustomDecorSprites(self, lMap) {
 			iDecor = oPlanDecor2[linkedType] && oPlanDecor2[linkedType][i];
 			if (iDecor) {
 				if (linkedData.map) {
-					if (iDecor.src === '')
-						iDecor.style.display = "";
+					iDecor.style.display = "";
 					iDecor.src = linkedData.map;
 				}
 				else if (iDecor.src) {

--- a/styles/decor-editor.css
+++ b/styles/decor-editor.css
@@ -1,41 +1,50 @@
 body {
-	background-image: url('../images/editor/fond_circuit_dark.jpg');
-	background-color: black;
-	background-size: cover;
-	background-attachment: fixed;
-	background-position: center bottom;
-	background-repeat: no-repeat;
-	font-family: Helvetica, arial, sans-serif;
-	text-align: center;
+    background-image: url('../images/editor/fond_circuit_dark.jpg');
+    background-color: black;
+    background-size: cover;
+    background-attachment: fixed;
+    background-position: center bottom;
+    background-repeat: no-repeat;
+    font-family: Helvetica, arial, sans-serif;
+    text-align: center;
     font-size: 1.2em;
 }
-h1, h2, h3 {
+
+h1,
+h2,
+h3 {
     margin: 5px auto;
 }
+
 h2 {
     margin-top: 10px;
     color: white;
     text-shadow: -2px 0 black, 0 2px black, 2px 0 black, 0 -2px black, -1px -1px black, -1px 1px black, 1px -1px black, 1px 1px black;
 }
+
 .decors-list-container {
     border-radius: 6px;
-    background-color: rgba(156,181,207, 0.85);
+    background-color: rgba(156, 181, 207, 0.85);
     max-width: 550px;
     padding: 10px 20px;
     margin: 10px auto;
 }
+
 .decors-list-empty {
     font-style: italic;
     margin-bottom: 5px;
 }
+
 .decors-list-more {
     position: relative;
     top: -0.1em;
 }
+
 .decors-list {
     margin-bottom: 4px;
 }
-.decors-list > div {
+
+.decors-list>div {
     padding: 5px 10px;
     max-width: 42px;
     display: inline-flex;
@@ -44,72 +53,88 @@ h2 {
     text-align: center;
     overflow: hidden;
 }
-.decors-list > div:hover {
+
+.decors-list>div:hover {
     background-color: #86a9e6;
 }
-.decors-list > div > img {
+
+.decors-list>div>img {
     height: 32px;
     align-self: center;
 }
+
 #decor-actions {
     font-size: 1.2em;
-	display: none;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 5px;
-	padding: 5px;
+    display: none;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 5px;
+    padding: 5px;
     background-color: #93b8f9;
 }
+
 #decor-actions button {
-	font-size: 0.7em;
-	padding: 3px 8px;
-	cursor: pointer;
-	margin: 0 2px;
+    font-size: 0.7em;
+    padding: 3px 8px;
+    cursor: pointer;
+    margin: 0 2px;
 }
+
 #decor-actions-name {
     color: #337;
     font-size: 0.8em;
-	margin-bottom: 0.15em;
-	font-weight: bold;
+    margin-bottom: 0.15em;
+    font-weight: bold;
 }
+
 #decor-actions-name:empty {
     display: none;
- }
+}
+
 #decor-actions-author {
-	font-size: 0.7em;
-	margin-bottom: 5px;
+    font-size: 0.7em;
+    margin-bottom: 5px;
 }
+
 #decor-actions .share-decor {
-	background-color: #8AD;
-	color: #6262EF;
+    background-color: #8AD;
+    color: #6262EF;
 }
+
 #decor-actions .share-decor:hover {
-	background-color: #9AF;
-	color: #545CB5;
+    background-color: #9AF;
+    color: #545CB5;
 }
+
 .decor-actions-stars {
-	padding: 0px 4px;
+    padding: 0px 4px;
 }
+
 .decor-actions-stars img {
-	width: 24px;
-	cursor: pointer;
+    width: 24px;
+    cursor: pointer;
 }
+
 #decor-actions .edit-decor {
-	background-color: #7E8;
-	color: #0A5;
+    background-color: #7E8;
+    color: #0A5;
 }
+
 #decor-actions .edit-decor:hover {
-	background-color: #7F8;
+    background-color: #7F8;
     color: #0B5;
 }
+
 #decor-actions .suppr-decor {
-	background-color: #F96;
-	color: #C24;
+    background-color: #F96;
+    color: #C24;
 }
+
 #decor-actions .suppr-decor:hover {
-	background-color: #FB7;
-	color: #D35;
+    background-color: #FB7;
+    color: #D35;
 }
+
 #decor-actions .collab-decor {
     display: block;
     margin-top: 0.4em;
@@ -117,28 +142,35 @@ h2 {
     margin-right: auto;
     font-size: 0.6em;
     padding: 0.1em 0.5em;
-	background-color: #7BF;
-	color: #35D;
+    background-color: #7BF;
+    color: #35D;
 }
+
 #decor-actions .collab-decor:hover {
-	background-color: #69F;
-	color: #24C;
+    background-color: #69F;
+    color: #24C;
 }
-.decors-list .decor-selected, .decors-list .decor-selected:hover {
-	background-color: #93b8f9;
+
+.decors-list .decor-selected,
+.decors-list .decor-selected:hover {
+    background-color: #93b8f9;
 }
+
 #decor-instructions {
     margin-bottom: 10px;
     font-size: 0.8em;
     text-align: left;
 }
+
 #decor-instructions .description {
     margin: 1em 0;
 }
+
 #decor-instructions ul {
     margin-top: 0.5em;
     padding-left: 1em;
 }
+
 #decor-instructions hr {
     margin-top: 10px;
     margin-bottom: 20px;
@@ -146,9 +178,11 @@ h2 {
     background-color: #359;
     border: none;
 }
+
 #decor-instructions.instructions-unshown {
-	display: none;
+    display: none;
 }
+
 .decor-type-selector button {
     width: 1.2em;
     height: 1.2em;
@@ -156,51 +190,66 @@ h2 {
     background-repeat: no-repeat;
     background-position: center;
 }
-.decor-type-selector #decor-type-selected, .decor-type-selector #decor-type-selected:hover {
+
+.decor-type-selector #decor-type-selected,
+.decor-type-selector #decor-type-selected:hover {
     background-color: #7CF;
 }
+
 #decor-new-form {
     text-align: left;
 }
+
 #decor-new-form h3 {
     text-align: center;
     position: relative;
     top: -0.2em;
 }
+
 #decor-new-form button[type="submit"] {
     width: 150px;
 }
+
 #decor-edit-form input[type="text"] {
     width: 200px;
 }
-.decor-editor-form input, .decor-editor-form button {
+
+.decor-editor-form input,
+.decor-editor-form button {
     font-size: 1em;
 }
+
 .decor-editor-form input[type="file"] {
     border: solid 1px #88B;
     background-color: #BFBFCF;
 }
+
 .decor-editor-form button {
     cursor: pointer;
     background-color: #69C;
     color: white;
     border-color: #48A;
 }
+
 .decor-editor-form button:hover {
     background-color: #669FD9;
     border-color: #59B;
 }
+
 .decor-editor-form button:disabled {
     cursor: default;
     opacity: 0.5;
 }
+
 .decor-editor-form button[type="submit"] {
     margin-top: 0.2em;
 }
+
 #decor-form-next {
     display: none;
     margin-top: 0.5em;
 }
+
 .decor-model {
     margin-top: 0.2em;
     margin-left: 0.2em;
@@ -211,12 +260,15 @@ h2 {
     max-width: 100%;
     overflow-x: auto;
 }
+
 .decor-model-label {
     margin-right: 0.3em;
 }
+
 .decor-model-value {
     line-height: 0;
 }
+
 #decor-extra-model {
     display: none;
     margin-top: 0.5em;
@@ -225,33 +277,39 @@ h2 {
     border-top: solid 1px black;
     font-size: 0.8em;
 }
+
 #error {
-	background-color: #D43;
-	color: #721;
-	font-weight: bold;
-	text-align: center;
-	display: inline-block;
-	padding: 8px 20px;
+    background-color: #D43;
+    color: #721;
+    font-weight: bold;
+    text-align: center;
+    display: inline-block;
+    padding: 8px 20px;
 }
+
 #error a {
-	color: #A5444C;
+    color: #A5444C;
 }
+
 #success {
-	background-color: #3D4;
-	color: #172;
-	font-weight: bold;
-	text-align: center;
-	display: inline-block;
-	padding: 8px 20px;
+    background-color: #3D4;
+    color: #172;
+    font-weight: bold;
+    text-align: center;
+    display: inline-block;
+    padding: 8px 20px;
 }
+
 #error a {
-	color: #A5444C;
+    color: #A5444C;
 }
+
 .advances-options {
     font-size: 0.9em;
     margin-top: 0.5em;
     color: #a8d4ff;
 }
+
 .advances-options a {
     display: inline-block;
     text-decoration: none;
@@ -260,34 +318,42 @@ h2 {
     position: relative;
     top: 2px;
 }
+
 .advances-options a:hover {
     text-decoration: underline;
     opacity: 1;
 }
+
 .decor-edit-preview {
     margin-bottom: 10px;
 }
+
 .decor-edit-preview a {
     position: relative;
     top: -0.2em;
     font-size: 0.8em;
 }
+
 .editor-navigation {
     font-size: 1rem;
 }
+
 .decor-preview {
     position: relative;
     margin-left: auto;
     margin-right: auto;
     overflow: hidden;
 }
+
 .decor-preview img {
     position: absolute;
     left: 0;
     top: 0;
     height: 100%;
 }
-.decor-preview img, .decors-list img {
+
+.decor-preview img,
+.decors-list img {
     image-rendering: optimizeSpeed;
     image-rendering: -moz-crisp-edges;
     image-rendering: -o-crisp-edges;
@@ -296,12 +362,39 @@ h2 {
     image-rendering: optimize-contrast;
     -ms-interpolation-mode: nearest-neighbor;
 }
+
 #decor-current-img-preview {
     margin-top: 5px;
     display: flex;
     align-items: center;
     justify-content: center;
 }
+
+#map-icon-toggle {
+    margin-top: 8px;
+    text-align: center;
+}
+
+a.map-icon-enable {
+    color: #00570a;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+a.map-icon-enable:hover {
+    color: #02630c;
+}
+
+a.map-icon-disable {
+    color: #B01;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+a.map-icon-disable:hover {
+    color: #D13;
+}
+
 #transparency-form-ctn {
     width: auto;
     max-width: 100%;
@@ -310,124 +403,149 @@ h2 {
     padding-left: 0;
     padding-right: 0;
 }
+
 #transparency-form-ctn h3 {
     margin-left: 0.75em;
     margin-right: 0.75em;
 }
+
 #transparency-form {
-	display: none;
+    display: none;
 }
-.decors-list-container + hr {
+
+.decors-list-container+hr {
     margin-top: 20px;
     margin-bottom: 10px;
     width: 80%;
     border-color: #BDE;
 }
+
 #select-transparency {
-	cursor: crosshair;
+    cursor: crosshair;
     margin-left: 20px;
     margin-right: 20px;
 }
+
 #transparency-color-preview {
-	display: inline-block;
-	width: 60px;
-	height: 25px;
-	border: solid 1px #BDE;
-	position: relative;
-	top: 6px;
+    display: inline-block;
+    width: 60px;
+    height: 25px;
+    border: solid 1px #BDE;
+    position: relative;
+    top: 6px;
 }
+
 #advanced-option-ctn {
     display: inline-flex;
     width: auto;
 }
+
 .advanced-option {
-	display: inline-block;
-	font-size: 0.7em;
-	margin-left: 10px;
-	margin-right: 10px;
-	padding: 10px 12px;
-	border-radius: 5px;
+    display: inline-block;
+    font-size: 0.7em;
+    margin-left: 10px;
+    margin-right: 10px;
+    padding: 10px 12px;
+    border-radius: 5px;
 }
+
 .advanced-option:hover {
-	background-color: #93b8f9;
+    background-color: #93b8f9;
 }
+
 .readonly .advanced-option {
     cursor: default;
     text-decoration: none;
 }
+
 .readonly .advanced-option:hover {
-	background-color: transparent;
+    background-color: transparent;
 }
+
 .readonly .option-form {
     pointer-events: none;
 }
+
 .readonly .option-form a {
     pointer-events: auto;
 }
+
 .readonly .option-form-reset {
     display: none;
 }
+
 .readonly .option-form-submit {
     visibility: hidden;
 }
+
 .advanced-option .option-bg {
     position: relative;
     width: 150px;
-	height: 150px;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 5px;
-	overflow: hidden;
+    height: 150px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 5px;
+    overflow: hidden;
 }
+
 .advanced-option.option-map .option-bg {
-	background-color: rgb(111,130,239);
+    background-color: rgb(111, 130, 239);
 }
+
 .advanced-option.option-map .option-bg img:first-child {
-	position: absolute;
-	left: 35px;
-	top: -190px;
+    position: absolute;
+    left: 35px;
+    top: -190px;
 }
+
 .advanced-option.option-map .option-bg #ic-decor-preview {
-	position: absolute;
-	left: 64px;
-	top: 64px;
-	width: 12px;
-	image-rendering: optimizeSpeed;
-	image-rendering: -moz-crisp-edges;
-	image-rendering: -o-crisp-edges;
-	image-rendering: -webkit-optimize-contrast;
-	image-rendering: pixelated;
-	image-rendering: optimize-contrast;
-	-ms-interpolation-mode: nearest-neighbor;
+    position: absolute;
+    left: 64px;
+    top: 64px;
+    width: 12px;
+    image-rendering: optimizeSpeed;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -o-crisp-edges;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: pixelated;
+    image-rendering: optimize-contrast;
+    -ms-interpolation-mode: nearest-neighbor;
 }
+
 .advanced-option.option-form h3 {
     margin-top: 0;
     margin-bottom: 0.25em;
 }
+
 .advanced-option.option-form form {
     min-width: 180px;
 }
-.advanced-option.option-form form > .option-form-props {
+
+.advanced-option.option-form form>.option-form-props {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
 }
+
 .advanced-option.option-form .option-form-group {
     display: flex;
     gap: 0.2em;
     align-items: center;
     justify-content: center;
 }
+
 .advanced-option.option-form .option-form-help {
     position: relative;
     top: -0.25em;
     font-size: 0.8em;
     text-decoration: none;
 }
-.advanced-option.option-form input[data-indeterminate] + * + .option-form-reset {
+
+.advanced-option.option-form input[data-indeterminate]+*+.option-form-reset {
     display: none;
 }
+
 .advanced-option.option-form .option-form-reset {
     margin-left: 0.4em;
     color: #D43;
@@ -435,137 +553,169 @@ h2 {
     position: relative;
     top: -0.1em;
 }
+
 .advanced-option.option-form .option-form-items {
     margin-top: 1em;
 }
+
 .advanced-option.option-form .option-form-items label {
     display: flex;
     gap: 0.25em;
     align-items: center;
 }
+
 .option-form-items-types {
     display: none;
     margin-bottom: 5px;
 }
+
 .option-form-items-types.shown {
     display: block;
 }
+
 .option-form-items-types input[type="button"] {
     width: 22px;
     background-size: auto 14px;
     background-repeat: no-repeat;
     background-position: center;
 }
+
 .option-form-items-types input[type="button"][data-selected="1"] {
-	background-color: #7CF;
+    background-color: #7CF;
 }
+
 .option-form-items-types input[type="button"]:not([data-selected="1"]) {
     opacity: 0.7;
     border-color: #93b8f988;
 }
+
 .advanced-option.option-form .option-form-reset:hover {
     color: #d66;
 }
+
 .advanced-option.option-form .option-form-reset-all {
     margin-left: 0.25em;
     display: none;
 }
+
 .advanced-option.option-form .option-form-help:hover {
     text-decoration: underline;
 }
+
 .advanced-option.option-form .option-form-submit {
     margin-top: 0.5em;
 }
+
 .advanced-option .option-label {
     white-space: nowrap;
 }
+
 #hitbox-size-label {
     display: none;
     text-align: left;
     margin-left: 24px;
 }
+
 #hitbox-size-label.show {
     display: block;
 }
+
 #hitbox-size-label #hitbox-in {
     width: 36px;
     margin-left: 3px;
 }
+
 #hitbox-preview {
     display: none;
-	position: absolute;
-	left: 64px;
-	top: 64px;
-	width: 12px;
+    position: absolute;
+    left: 64px;
+    top: 64px;
+    width: 12px;
     height: 12px;
     border: dashed 2px red;
 }
+
 .decors-bottom {
-	margin-top: 10px;
-	margin-bottom: 10px;
-	height: 60px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    height: 60px;
 }
+
 .collab-popup.collab-decor {
     background-color: #14465f;
     text-align: left;
     color: #DEF;
     font-size: 0.9em;
 }
+
 .collab-popup.collab-decor .collab-popup-close {
     background-color: #134;
 }
+
 .collab-popup.collab-decor .collab-popup-close:hover {
     background-color: #145;
 }
+
 .collab-popup.collab-decor h2 {
     font-size: 1.5em;
     color: white;
 }
+
 .collab-popup.collab-decor h3 {
     color: white;
     margin-bottom: 0.1em;
 }
+
 .collab-popup.collab-decor .collab-btn-primary {
     background-color: #58B;
     color: white;
     border-color: #379;
 }
+
 .collab-popup.collab-decor .collab-btn-primary:hover {
     cursor: pointer;
     background-color: #69C;
     border-color: #48A;
 }
+
 .decors-collab {
     font-size: 0.8em;
 }
+
 #decors-collab {
     display: none;
     margin-top: 0.25em;
 }
+
 #decors-collab.shown {
     display: block;
 }
+
 #decors-collab label {
     display: flex;
     flex-wrap: wrap;
     gap: 0.25em;
     align-items: baseline;
-	justify-content: center;
+    justify-content: center;
 }
+
 #decors-collab label a {
     position: relative;
     top: -0.6em;
     font-size: 0.6em;
 }
+
 #decors-collab input[type="url"] {
     flex: 1;
 }
+
 #decors-collab button {
     cursor: pointer;
     background-color: #69C;
     color: white;
     border-color: #48A;
 }
+
 #decors-collab button:hover {
     background-color: #669FD9;
     border-color: #59B;


### PR DESCRIPTION
This PR adds a new option in decor editor to make the decor not render in the minimap. This is an optimization for circuits with lots of decor and also removes the need to upload a transparent icon which was the current workaround