### PR TITLE
fix(Grand Prix): Obfuscate map list to prevent hacking by replace script. An added difficulty for hackers.

### DIFF
--- a/scripts/maps.php
+++ b/scripts/maps.php
@@ -1,6 +1,30 @@
 <?php
 header('Content-Type: text/javascript');
 header('Cache-Control: max-age=600000');
-?>function listMaps(){return<?php
-    echo file_get_contents('../php/includes/mk/maps.json');
-?>}
+
+$data = file_get_contents('../php/includes/mk/maps.json');
+$key = 0x5A;
+$out = '';
+
+for ($i = 0; $i < strlen($data); $i++) {
+    $out .= chr(ord($data[$i]) ^ $key);
+}
+
+$encoded = base64_encode($out);
+
+echo "function listMaps(){ return JSON.parse(decodeMaps(\"$encoded\")); }";
+
+?>
+
+
+function decodeMaps(b64) {
+    const key = 0x5A;
+    const bin = atob(b64);
+    let out = "";
+
+    for (let i = 0; i < bin.length; i++) {
+        out += String.fromCharCode(bin.charCodeAt(i) ^ key);
+    }
+
+    return out;
+}


### PR DESCRIPTION
There is still a lot more that could be added, but we can no longer directly modify multi-cut paths using the devtools.

We could add an automatic consistency check for the race at the end later on, to ensure the consistency of the route taken by the player.

**Initial issue**:

From the client, you can modify the maps.php script file and the contents of listMaps().

This meant that you could modify the track and post absurd times on the leaderboards for the basic tracks.

**Solutions**:

Obfuscate the code to make it less readable to the client.
Implement a copy-protection script of some sort to prevent the file from being overwritten and the script replaced.

**Remaining tasks**:

A workaround is always possible; we are never completely safe from the client. Use the "ghost" (which records all movements) to verify the consistency of the path taken. This final step may be complicated and is not necessarily a top priority.