### PR TITLE
fix(editor): Fix bug when Holes or Teleporters are selected, image won't be changed.

### DIFF
--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -5858,7 +5858,16 @@ var commonTools = {
 				else
 					self.state.respawnType = document.getElementById(self._respawn_selector_id).value;
 			}
-			document.getElementById("checkpoint-respawn-reset").style.display = "";
+			let checkpointRespawnReset = document.getElementById("checkpoint-respawn-reset");
+			if(checkpointRespawnReset) {
+				checkpointRespawnReset.style.display = "";
+			}
+			else {
+				console.log(
+					"%cCheckpoint respawn reset button not found, it won't be displayed",
+					"background: rgba(70, 175, 227, 0.18); color: #1f4f6b; padding: 2px 6px; border-radius: 3px;"
+				);
+			}
 		},
 		"click" : function(self,point,extra) {
 			var respawnNode = self.state.respawnNode;


### PR DESCRIPTION
Reported by Nodac [Battle Mode Editor Bug](https://discord.com/channels/308979137480097793/1504904569464029314/1504904569464029314)

**<ins>Context</ins>**:

When you use overrides, you select holes or teleporters, image of course won't be changed.
You are forced to set other modes to change image. It is unpratictical.

**<ins>Problem</ins>**:

An error occure when you chose holes or teleporters options, because checkpoint-respawn-reset element is null and resume method in commonTools can't change style. So it crash and the following code is not executed. So image is not changed.

**<ins>Solution</ins>**:

I've had a checking condition, if element exist, we change his style, else, a log console is written.

<br>
<br>

> [!NOTE]
> I'm not sure if this element is set to null on purpose when "teleporters" or "holes" is selected?