### PR TITLE
Block following permanently banned members, hide them from follower lists

### DIFF
--- a/php/includes/banUtils.php
+++ b/php/includes/banUtils.php
@@ -3,7 +3,10 @@ function isPermanentlyBanned($player) {
 	$getBan = mysql_fetch_array(mysql_query('SELECT j.banned,b.end_date FROM `mkjoueurs` j LEFT JOIN `mkbans` b ON j.id=b.player WHERE j.id="'. $player .'"'));
 	return $getBan && $getBan['banned'] && !$getBan['end_date'];
 }
-function notPermanentlyBannedSql($playerColumn) {
-	return 'NOT EXISTS(SELECT * FROM `mkjoueurs` pbj LEFT JOIN `mkbans` pbb ON pbj.id=pbb.player WHERE pbj.id='. $playerColumn .' AND pbj.banned!=0 AND pbb.end_date IS NULL)';
+function notPermanentlyBannedJoin($playerColumn) {
+	return ' LEFT JOIN `mkjoueurs` pbj ON pbj.id='. $playerColumn .' LEFT JOIN `mkbans` pbb ON pbb.player='. $playerColumn;
+}
+function notPermanentlyBannedWhere() {
+	return 'NOT (COALESCE(pbj.banned,0)!=0 AND pbb.end_date IS NULL)';
 }
 ?>

--- a/php/includes/banUtils.php
+++ b/php/includes/banUtils.php
@@ -1,0 +1,9 @@
+<?php
+function isPermanentlyBanned($player) {
+	$getBan = mysql_fetch_array(mysql_query('SELECT j.banned,b.end_date FROM `mkjoueurs` j LEFT JOIN `mkbans` b ON j.id=b.player WHERE j.id="'. $player .'"'));
+	return $getBan && $getBan['banned'] && !$getBan['end_date'];
+}
+function notPermanentlyBannedSql($playerColumn) {
+	return 'NOT EXISTS(SELECT * FROM `mkjoueurs` pbj LEFT JOIN `mkbans` pbb ON pbj.id=pbb.player WHERE pbj.id='. $playerColumn .' AND pbj.banned!=0 AND pbb.end_date IS NULL)';
+}
+?>

--- a/php/includes/banUtils.php
+++ b/php/includes/banUtils.php
@@ -6,7 +6,7 @@ function isPermanentlyBanned($player) {
 function notPermanentlyBannedJoin($playerColumn) {
 	return ' LEFT JOIN `mkjoueurs` pbj ON pbj.id='. $playerColumn .' LEFT JOIN `mkbans` pbb ON pbb.player='. $playerColumn;
 }
-function notPermanentlyBannedWhere() {
+function notPermanentlyBannedCondition() {
 	return 'NOT (COALESCE(pbj.banned,0)!=0 AND pbb.end_date IS NULL)';
 }
 ?>

--- a/php/includes/menu.php
+++ b/php/includes/menu.php
@@ -337,7 +337,8 @@
 							$toDelete = true;
 						break;
 					case 'new_followuser' :
-						if ($getFollower = mysql_fetch_array(mysql_query('SELECT * FROM `mkfollowusers` WHERE follower="'. $myNotif['link'] .'" AND followed="'. $id .'"'))) {
+						require_once('banUtils.php');
+						if (($getFollower = mysql_fetch_array(mysql_query('SELECT * FROM `mkfollowusers` WHERE follower="'. $myNotif['link'] .'" AND followed="'. $id .'"'))) && !isPermanentlyBanned($getFollower['follower'])) {
 							$notifData['link'] = 'listFollowers.php';
 							$notifData['sender'] = $getFollower['follower'];
 						}

--- a/php/pages/follow-user.php
+++ b/php/pages/follow-user.php
@@ -5,9 +5,10 @@ if (isset($_GET['user'])) {
 		include('../includes/initdb.php');
 		if (mysql_fetch_array(mysql_query('SELECT * FROM `mkjoueurs` WHERE id="'. $_GET['user'] .'"'))) {
 			if (isset($_GET['follow'])) {
+				require_once('../includes/banUtils.php');
 				$getBanned = mysql_fetch_array(mysql_query('SELECT banned FROM `mkjoueurs` WHERE id="'. $id .'"'));
 				$isBanned = $getBanned && $getBanned['banned'];
-				if (!$isBanned) {
+				if (!$isBanned && !isPermanentlyBanned($_GET['user'])) {
 					mysql_query('INSERT IGNORE INTO `mkfollowusers` VALUES("'. $id .'","'. $_GET['user'] .'",NULL)');
 					mysql_query('INSERT INTO `mknotifs` SET type="new_followuser", user="'. $_GET['user'] .'", link="'.$id.'"');
 				}

--- a/php/pages/follow-user.php
+++ b/php/pages/follow-user.php
@@ -3,8 +3,8 @@ if (isset($_GET['user'])) {
 	include('../includes/session.php');
 	if ($id && ($id!=$_GET['user'])) {
 		include('../includes/initdb.php');
-		if (mysql_fetch_array(mysql_query('SELECT * FROM `mkjoueurs` WHERE id="'. $_GET['user'] .'"'))) {
-			if (isset($_GET['follow'])) {
+		if (isset($_GET['follow'])) {
+			if (mysql_fetch_array(mysql_query('SELECT * FROM `mkjoueurs` WHERE id="'. $_GET['user'] .'"'))) {
 				require_once('../includes/banUtils.php');
 				$getBanned = mysql_fetch_array(mysql_query('SELECT banned FROM `mkjoueurs` WHERE id="'. $id .'"'));
 				$isBanned = $getBanned && $getBanned['banned'];
@@ -13,11 +13,14 @@ if (isset($_GET['user'])) {
 					mysql_query('INSERT INTO `mknotifs` SET type="new_followuser", user="'. $_GET['user'] .'", link="'.$id.'"');
 				}
 			}
-			else
-				mysql_query('DELETE FROM `mkfollowusers` WHERE follower="'. $id .'" AND followed="'. $_GET['user'] .'"');
 		}
+		else
+			mysql_query('DELETE FROM `mkfollowusers` WHERE follower="'. $id .'" AND followed="'. $_GET['user'] .'"');
 		mysql_close();
-		header('location: profil.php?id='.urlencode($_GET['user']).'&followed='.(isset($_GET['follow'])?1:0));
+		if (isset($_GET['src']) && ($_GET['src'] === 'follows'))
+			header('location: listFollowed.php'. (isset($_GET['page']) ? '?page='.urlencode($_GET['page']):''));
+		else
+			header('location: profil.php?id='.urlencode($_GET['user']).'&followed='.(isset($_GET['follow'])?1:0));
 	}
 	else
 		header('location: profil.php?id='.urlencode($_GET['user']));

--- a/php/pages/listFollowed.php
+++ b/php/pages/listFollowed.php
@@ -37,7 +37,8 @@ include('../includes/menu.php');
 	}
 	$dateFormat = $language ? '%Y-%m-%d':'le %d/%m/%y';
 	$today = time();
-	$getUsers = mysql_query('SELECT followed,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE follower="'. $id .'" ORDER BY date DESC');
+	require_once('../includes/banUtils.php');
+	$getUsers = mysql_query('SELECT followed,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE follower="'. $id .'" AND '. notPermanentlyBannedSql('followed') .' ORDER BY date DESC');
 	$users = array();
 	while ($user = mysql_fetch_array($getUsers))
 		$users[] = $user;

--- a/php/pages/listFollowed.php
+++ b/php/pages/listFollowed.php
@@ -15,7 +15,7 @@ include('../includes/avatars.php');
 ?>
 <link rel="stylesheet" type="text/css" href="styles/forum.css" />
 <link rel="stylesheet" type="text/css" href="styles/profil.css" />
-<link rel="stylesheet" type="text/css" href="styles/followers.css" />
+<link rel="stylesheet" type="text/css" href="styles/followers.css?reload=1" />
 
 <?php
 include('../includes/o_online.php');
@@ -37,8 +37,7 @@ include('../includes/menu.php');
 	}
 	$dateFormat = $language ? '%Y-%m-%d':'le %d/%m/%y';
 	$today = time();
-	require_once('../includes/banUtils.php');
-	$getUsers = mysql_query('SELECT followed,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE follower="'. $id .'" AND '. notPermanentlyBannedSql('followed') .' ORDER BY date DESC');
+	$getUsers = mysql_query('SELECT followed,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE follower="'. $id .'" ORDER BY date DESC');
 	$users = array();
 	while ($user = mysql_fetch_array($getUsers))
 		$users[] = $user;
@@ -52,19 +51,25 @@ include('../includes/menu.php');
 	<div class="following-users">
 	<?php
 	foreach ($users as $user) {
+		$pseudo = get_pseudo_text($user['followed']);
+		$displayName = ($pseudo === null) ? ($language ? 'this deleted account':'ce compte supprimé'):$pseudo;
+		$confirmMsg = $language ? 'Unfollow '. $displayName .'?':'Ne plus suivre '. $displayName .' ?';
 		?>
-		<a class="follower-item" href="profil.php?id=<?php echo $user['followed']; ?>" title="<?php echo get_pseudo_text($user['followed']); ?>">
-			<?php
-			echo '<div class="avatar-ctn">';
-			print_avatar($user['followed'],50);
-			echo '</div>';
-			echo '<div class="nick-ctn">';
-			echo get_pseudo_text($user['followed']);
-			echo '<br />';
-			echo '<span class="nick-info">'. ($language ? 'Followed since '.$user['infosDate']:'Suivi depuis '.$user['infosDate']) .'</span>';
-			echo '</div>';
-			?>
-		</a>
+		<div class="follower-item-ctn">
+			<a class="follower-item" href="profil.php?id=<?php echo $user['followed']; ?>" title="<?php echo htmlspecialchars($displayName); ?>">
+				<?php
+				echo '<div class="avatar-ctn">';
+				print_avatar($user['followed'],50);
+				echo '</div>';
+				echo '<div class="nick-ctn">';
+				echo $pseudo;
+				echo '<br />';
+				echo '<span class="nick-info">'. ($language ? 'Followed since '.$user['infosDate']:'Suivi depuis '.$user['infosDate']) .'</span>';
+				echo '</div>';
+				?>
+			</a>
+			<a class="unfollow-user" href="follow-user.php?user=<?php echo urlencode($user['followed']); ?>&amp;src=follows&amp;page=<?php echo $page; ?>" title="<?php echo $language ? 'Unfollow':'Ne plus suivre'; ?>" onclick="return confirm('<?php echo htmlspecialchars(addslashes($confirmMsg), ENT_QUOTES); ?>')">&times;</a>
+		</div>
 		<?php
 	}
 	?>

--- a/php/pages/listFollowers.php
+++ b/php/pages/listFollowers.php
@@ -39,7 +39,7 @@ include('../includes/menu.php');
 	$dateFormat = $language ? '%Y-%m-%d':'le %d/%m/%y';
 	$today = time();
 	require_once('../includes/banUtils.php');
-	$getUsers = mysql_query('SELECT f.follower,DATE_FORMAT(f.date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $id .'" AND '. notPermanentlyBannedWhere() .' ORDER BY f.date DESC');
+	$getUsers = mysql_query('SELECT f.follower,DATE_FORMAT(f.date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $id .'" AND '. notPermanentlyBannedCondition() .' ORDER BY f.date DESC');
 	$users = array();
 	while ($user = mysql_fetch_array($getUsers))
 		$users[] = $user;

--- a/php/pages/listFollowers.php
+++ b/php/pages/listFollowers.php
@@ -16,7 +16,7 @@ include('../includes/avatars.php');
 ?>
 <link rel="stylesheet" type="text/css" href="styles/forum.css" />
 <link rel="stylesheet" type="text/css" href="styles/profil.css" />
-<link rel="stylesheet" type="text/css" href="styles/followers.css" />
+<link rel="stylesheet" type="text/css" href="styles/followers.css?reload=1" />
 
 <?php
 include('../includes/o_online.php');
@@ -39,7 +39,7 @@ include('../includes/menu.php');
 	$dateFormat = $language ? '%Y-%m-%d':'le %d/%m/%y';
 	$today = time();
 	require_once('../includes/banUtils.php');
-	$getUsers = mysql_query('SELECT follower,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE followed="'. $id .'" AND '. notPermanentlyBannedSql('follower') .' ORDER BY date DESC');
+	$getUsers = mysql_query('SELECT f.follower,DATE_FORMAT(f.date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $id .'" AND '. notPermanentlyBannedWhere() .' ORDER BY f.date DESC');
 	$users = array();
 	while ($user = mysql_fetch_array($getUsers))
 		$users[] = $user;

--- a/php/pages/listFollowers.php
+++ b/php/pages/listFollowers.php
@@ -38,7 +38,8 @@ include('../includes/menu.php');
 	}
 	$dateFormat = $language ? '%Y-%m-%d':'le %d/%m/%y';
 	$today = time();
-	$getUsers = mysql_query('SELECT follower,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE followed="'. $id .'" ORDER BY date DESC');
+	require_once('../includes/banUtils.php');
+	$getUsers = mysql_query('SELECT follower,DATE_FORMAT(date, "'. $dateFormat .'") AS infosDate FROM `mkfollowusers` WHERE followed="'. $id .'" AND '. notPermanentlyBannedSql('follower') .' ORDER BY date DESC');
 	$users = array();
 	while ($user = mysql_fetch_array($getUsers))
 		$users[] = $user;

--- a/php/pages/profil.php
+++ b/php/pages/profil.php
@@ -291,7 +291,8 @@ include('../includes/menu.php');
 				<h2><?php echo $language ? 'General stats':'Stats générales'; ?></h2>
 				<div class="player-followers">
 				<?php
-				$followedUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb, '.($id?'SUM(follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` WHERE followed="'. $profileId .'"'));
+				require_once('../includes/banUtils.php');
+				$followedUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb, '.($id?'SUM(follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` WHERE followed="'. $profileId .'" AND '. notPermanentlyBannedSql('follower')));
 				$s = plural($followedUsers['nb']);
 				$view = $language ? 'View' : 'Voir';
 				echo '<img src="images/followers.png" alt="Followers" />';
@@ -302,13 +303,14 @@ include('../includes/menu.php');
 				}
 				elseif ($id) {
 					$isFollower = $followedUsers['userisfollower'];
-					echo ' <a class="follow-user'. ($isFollower ? ' followed':'') .'" href="follow-user.php?user='. $profileId . ($isFollower?'':'&amp;follow') .'"><span>'.($isFollower?'&ndash;':'+').'</span>'. ($language ? ($isFollower?'Unfollow':'Follow'):($isFollower?'Ne plus suivre':'Suivre')) .'</a></span>';
+					if ($isFollower || !isPermanentlyBanned($profileId))
+						echo ' <a class="follow-user'. ($isFollower ? ' followed':'') .'" href="follow-user.php?user='. $profileId . ($isFollower?'':'&amp;follow') .'"><span>'.($isFollower?'&ndash;':'+').'</span>'. ($language ? ($isFollower?'Unfollow':'Follow'):($isFollower?'Ne plus suivre':'Suivre')) .'</a></span>';
 				}
 				?>
 				</div>
 				<div class="player-followers">
 				<?php
-				$followingUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb FROM `mkfollowusers` WHERE follower="'. $profileId .'"'));
+				$followingUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb FROM `mkfollowusers` WHERE follower="'. $profileId .'" AND '. notPermanentlyBannedSql('followed')));
 				$s = plural($followingUsers['nb']);
 				echo '<img src="images/followed.png" alt="Following" />';
 				echo '<strong>'. $followingUsers['nb'] . ' '. ($language ? 'following' : 'abonnement'.$s) .'</strong>';

--- a/php/pages/profil.php
+++ b/php/pages/profil.php
@@ -292,7 +292,7 @@ include('../includes/menu.php');
 				<div class="player-followers">
 				<?php
 				require_once('../includes/banUtils.php');
-				$followedUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb, '.($id?'SUM(f.follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $profileId .'" AND '. notPermanentlyBannedWhere()));
+				$followedUsers = mysql_fetch_array(mysql_query('SELECT COALESCE(SUM('. notPermanentlyBannedCondition() .'),0) AS nb, '.($id?'SUM(f.follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $profileId .'"'));
 				$s = plural($followedUsers['nb']);
 				$view = $language ? 'View' : 'Voir';
 				echo '<img src="images/followers.png" alt="Followers" />';

--- a/php/pages/profil.php
+++ b/php/pages/profil.php
@@ -292,7 +292,7 @@ include('../includes/menu.php');
 				<div class="player-followers">
 				<?php
 				require_once('../includes/banUtils.php');
-				$followedUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb, '.($id?'SUM(follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` WHERE followed="'. $profileId .'" AND '. notPermanentlyBannedSql('follower')));
+				$followedUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb, '.($id?'SUM(f.follower='.$id.')':'0').' AS userisfollower FROM `mkfollowusers` f'. notPermanentlyBannedJoin('f.follower') .' WHERE f.followed="'. $profileId .'" AND '. notPermanentlyBannedWhere()));
 				$s = plural($followedUsers['nb']);
 				$view = $language ? 'View' : 'Voir';
 				echo '<img src="images/followers.png" alt="Followers" />';
@@ -310,7 +310,7 @@ include('../includes/menu.php');
 				</div>
 				<div class="player-followers">
 				<?php
-				$followingUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb FROM `mkfollowusers` WHERE follower="'. $profileId .'" AND '. notPermanentlyBannedSql('followed')));
+				$followingUsers = mysql_fetch_array(mysql_query('SELECT COUNT(*) AS nb FROM `mkfollowusers` WHERE follower="'. $profileId .'"'));
 				$s = plural($followingUsers['nb']);
 				echo '<img src="images/followed.png" alt="Following" />';
 				echo '<strong>'. $followingUsers['nb'] . ' '. ($language ? 'following' : 'abonnement'.$s) .'</strong>';

--- a/styles/followers.css
+++ b/styles/followers.css
@@ -26,6 +26,31 @@
 	-webkit-hyphens: auto;
 	hyphens: auto;
 }
+.follower-item-ctn {
+	position: relative;
+	display: inline-flex;
+	margin: 5px;
+}
+.follower-item-ctn .follower-item {
+	margin: 0;
+}
+.unfollow-user {
+	position: absolute;
+	top: 1px;
+	right: 3px;
+	width: 16px;
+	height: 16px;
+	line-height: 15px;
+	text-align: center;
+	border-radius: 50%;
+	color: #FB3;
+	font-size: 15px;
+	text-decoration: none;
+}
+.unfollow-user:hover {
+	background-color: #F70;
+	color: #FFF;
+}
 .follower-item .avatar {
 	font-size: 30px;
 	display: flex;


### PR DESCRIPTION
Implements the Discord request in thread `1531336398785872002` (nodac): permanently banned accounts should not be followable, and should disappear from follower lists. The motivating case was an account with a slur for a username showing up as "X now follows you", with no way for the recipient to get rid of it.

## Behaviour

A ban counts as **permanent** when `mkjoueurs.banned != 0` and `mkbans.end_date IS NULL` — i.e. the moderator did not tick "Ban until". Temporary bans are unaffected.

| Where | Change |
|---|---|
| `follow-user.php` | Following a permanently banned account is rejected (no row, no notification). Unfollowing still works. |
| `listFollowers.php` | Permanently banned followers are excluded. |
| `profil.php` | The followers count excludes them, so the number matches the list. |
| `profil.php` | The Follow button is hidden on a permanently banned profile — but still shown as *Unfollow* if you already follow them, so existing links can be cleaned up. |
| `menu.php` | The "X now follows you" notification is dropped when the follower is permanently banned. |

Filtering happens at read time; `mkfollowusers` is never touched by the ban, so unbanning restores every follow exactly as it was.

The "following" direction is deliberately **not** filtered — hiding accounts *you* chose to follow was not what was reported, and it would stop you from seeing and undoing the follow.

## Performance

The filter runs twice on every profile page view, so it was measured on production rather than guessed at (with `SQL_NO_CACHE`, since the query cache is on and hides the real cost):

| Formulation | Median, 408-follower profile (worst case on the site) |
|---|---|
| No filter | 0.8 ms |
| Correlated `NOT EXISTS` | 13 ms |
| **Anti-join (shipped)** | **5.9 ms** |

Cost is linear in follower count. The average account has 4.2 followers (~0.05 ms), and only 10 accounts sitewide have 200+.

The anti-join was checked for exact equivalence against the correlated form across all 10,846 users with followers, in both directions: **0 mismatches**. It uses `LEFT JOIN` + `COALESCE` rather than `INNER JOIN` because 485 follow rows point at players hard-deleted from `mkjoueurs`, which an inner join would have silently dropped.

## Unfollow control on the follows list

Separately requested by members: each card on `listFollowed.php` gets a `×` in the top-right with a confirm dialog, returning to the same page of the list.

This also required a backend fix. `follow-user.php` wrapped *both* the follow and unfollow branches in a check that the target still exists in `mkjoueurs`. For hard-deleted accounts that row is gone, so the `DELETE` never ran and the follow was genuinely unremovable — their profile page is empty, so there was no Unfollow button either. The existence check now guards only the follow branch.

`followers.css` gets a `?reload=1` cache-buster, since it had none and returning visitors would otherwise get an unstyled `×`.

## Testing

- Verified against the dockerized site with a real account following 30 hard-deleted players: the deleted-account card renders, unfollowing returns `302 → listFollowed.php?page=1`, and the row is removed.
- Follow path re-checked after the restructure: permanently banned target → no row; nonexistent target → no row; normal target → row plus notification.
- Visual check of the `×` in default and hover states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rrdP6oPN4tHLupi9hXMmc
