### PR TITLE
chore(tests): clean up e2e fixtures instead of leaking them into the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ npx playwright test --debug
 npx playwright codegen
   Auto generate tests with Codegen.
 ```
+
+The tests create real data (tracks, cups, forum topics) and delete it again afterwards,
+which needs a direct connection to the database as well as to the site. Both default to
+the addresses `docker-compose.yml` publishes, and are overridable:
+
+```
+BASE_URL          site under test        (default http://127.0.0.1:8080)
+MKPC_DB_HOST      database host          (default 127.0.0.1)
+MKPC_DB_PORT      database port          (default 8306)
+MKPC_DB_USER      database user          (default mkpc_user)
+MKPC_DB_PASSWORD  database password      (default mkpc_pwd)
+MKPC_DB_NAME      database name          (default mkpc)
+```
+
+Cleanup removes everything matching a spec's scope, from previous runs as well as the
+current one, so a run that was interrupted is repaired by the next one. Because that scope
+is per spec file and not per checkout, run only one copy of the suite against a given
+database at a time.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ MKPC_DB_PASSWORD  database password      (default mkpc_pwd)
 MKPC_DB_NAME      database name          (default mkpc)
 ```
 
-Cleanup removes everything matching a spec's scope, from previous runs as well as the
-current one, so a run that was interrupted is repaired by the next one. Because that scope
-is per spec file and not per checkout, run only one copy of the suite against a given
-database at a time.
+Cleanup runs once before the suite and once after it (`tests/global-cleanup.ts`), and
+removes everything in scope from previous runs as well as the current one, so a run that
+was interrupted is repaired by the next one. A new test needs nothing registered there: it
+only has to name its creations `e2e-*`. Because the scope is a name prefix and not a
+checkout, run only one copy of the suite against a given database at a time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.51.1"
+        "@playwright/test": "^1.51.1",
+        "mysql2": "^3.23.3"
       }
     },
     "node_modules/@playwright/test": {
@@ -28,6 +29,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -41,6 +63,98 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.3.tgz",
+      "integrity": "sha512-ehp9HEKr4wVJaBOUVxNFa+CNrsCCCZ6363/jbGhb7WpEmSRNIXjHBjFs5K2s2cXn7j/RhDieejsQJ6nfUwD6vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/playwright": {
@@ -74,6 +188,37 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     }
   },
   "dependencies": {
@@ -86,12 +231,88 @@
         "playwright": "1.51.1"
       }
     },
+    "@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true
+    },
+    "long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true
+    },
+    "lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true
+    },
+    "mysql2": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.3.tgz",
+      "integrity": "sha512-ehp9HEKr4wVJaBOUVxNFa+CNrsCCCZ6363/jbGhb7WpEmSRNIXjHBjFs5K2s2cXn7j/RhDieejsQJ6nfUwD6vQ==",
+      "dev": true,
+      "requires": {
+        "aws-ssl-profiles": "^1.1.2",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "requires": {
+        "lru.min": "^1.1.0"
+      }
     },
     "playwright": {
       "version": "1.51.1",
@@ -108,6 +329,25 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
       "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
       "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/tmalahie/mkpc#readme",
   "devDependencies": {
-    "@playwright/test": "^1.51.1"
+    "@playwright/test": "^1.51.1",
+    "mysql2": "^3.23.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  /* Remove fixtures left by a previous run, and again once this one is done. */
+  globalSetup: './tests/global-cleanup.ts',
+  globalTeardown: './tests/global-cleanup.ts',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/cup-advanced-options.spec.ts
+++ b/tests/cup-advanced-options.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { login, createCircuits, useCreationCleanup } from './helpers/mkpc';
 
+// Serial, because the cleanup hooks below delete every creation owned by OWNER.
+// beforeAll/afterAll run once per *worker*, so under fullyParallel a worker that
+// finishes its share of this file would run the cleanup while another worker is
+// still using the circuits built by the `circuit runtime cupOpts` beforeAll.
+test.describe.configure({ mode: 'serial' });
+
 // Own owner tag so this file's cleanup cannot touch fixtures belonging to a
 // spec running concurrently in another worker.
 const OWNER = 'e2e-cup-bot';

--- a/tests/cup-advanced-options.spec.ts
+++ b/tests/cup-advanced-options.spec.ts
@@ -1,16 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { login, createCircuits, useCreationCleanup } from './helpers/mkpc';
 
-// Serial, because the cleanup hooks below delete every creation owned by OWNER.
-// beforeAll/afterAll run once per *worker*, so under fullyParallel a worker that
-// finishes its share of this file would run the cleanup while another worker is
-// still using the circuits built by the `circuit runtime cupOpts` beforeAll.
-test.describe.configure({ mode: 'serial' });
-
 // Own owner tag so this file's cleanup cannot touch fixtures belonging to a
-// spec running concurrently in another worker.
+// spec running concurrently in another worker. The cleanup hooks live inside the
+// `circuit runtime cupOpts` describe below - the only place here that creates
+// anything - rather than at file scope: beforeAll/afterAll run once per *worker*,
+// so a file-scope hook would let one worker wipe the circuits another is still
+// using. That describe is serial, which confines both to a single worker.
 const OWNER = 'e2e-cup-bot';
-useCreationCleanup(OWNER);
 
 test('simple cup editor shows Advanced Options with per-CPU rows', async ({ page }) => {
   await login(page);
@@ -167,6 +164,7 @@ test('cup editor preserves orphaned custom item distribution', async ({ page }) 
 // circuits by id with no ownership check, so a fresh page can load them.
 test.describe('circuit runtime cupOpts', () => {
   test.describe.configure({ mode: 'serial' });
+  useCreationCleanup(OWNER);
   let cupQuery: string;
 
   test.beforeAll(async ({ browser }) => {

--- a/tests/cup-advanced-options.spec.ts
+++ b/tests/cup-advanced-options.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { login, createCircuits } from './helpers/mkpc';
+import { login, createCircuits, useCreationCleanup } from './helpers/mkpc';
+
+// Own owner tag so this file's cleanup cannot touch fixtures belonging to a
+// spec running concurrently in another worker.
+const OWNER = 'e2e-cup-bot';
+useCreationCleanup(OWNER);
 
 test('simple cup editor shows Advanced Options with per-CPU rows', async ({ page }) => {
   await login(page);
@@ -161,7 +166,7 @@ test.describe('circuit runtime cupOpts', () => {
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
     await login(page);
-    const ids = await createCircuits(page.request, 4);
+    const ids = await createCircuits(page.request, 4, OWNER);
     cupQuery = [0, 1, 2, 3].map((i) => 'cid' + i + '=' + ids[i % ids.length]).join('&');
     await page.close();
   });

--- a/tests/cup-advanced-options.spec.ts
+++ b/tests/cup-advanced-options.spec.ts
@@ -1,12 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { login, createCircuits, useCreationCleanup } from './helpers/mkpc';
+import { login, createCircuits } from './helpers/mkpc';
 
-// Own owner tag so this file's cleanup cannot touch fixtures belonging to a
-// spec running concurrently in another worker. The cleanup hooks live inside the
-// `circuit runtime cupOpts` describe below - the only place here that creates
-// anything - rather than at file scope: beforeAll/afterAll run once per *worker*,
-// so a file-scope hook would let one worker wipe the circuits another is still
-// using. That describe is serial, which confines both to a single worker.
+// Tags this file's creations so tests/global-cleanup.ts sweeps them up afterwards.
 const OWNER = 'e2e-cup-bot';
 
 test('simple cup editor shows Advanced Options with per-CPU rows', async ({ page }) => {
@@ -164,7 +159,6 @@ test('cup editor preserves orphaned custom item distribution', async ({ page }) 
 // circuits by id with no ownership check, so a fresh page can load them.
 test.describe('circuit runtime cupOpts', () => {
   test.describe.configure({ mode: 'serial' });
-  useCreationCleanup(OWNER);
   let cupQuery: string;
 
   test.beforeAll(async ({ browser }) => {

--- a/tests/forum.spec.ts
+++ b/tests/forum.spec.ts
@@ -1,73 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { randomBytes } from 'crypto';
-import { sql } from './helpers/db';
+import { newTopicName } from './helpers/forum';
 
 const ADMIN_USER = 'wargor';
 const ADMIN_PASSWORD = 'aaaa';
 const ADMIN_USERNAME_PRINTED = "Wargor";
 
-const RANDOM_ID = randomBytes(10).toString('hex');
-const TOPIC_NAME = "New topic " + RANDOM_ID;
-const TOPIC_CONTENT = "New topic content " + RANDOM_ID;
-
-// Each run posts a topic under a fresh random suffix, so cleanup matches the
-// shape of the generated title rather than one run's value: it clears this run's
-// topic and any left behind by earlier ones. The anchored regexp keeps it from
-// touching a real topic that merely starts with "New topic".
-const TOPIC_PATTERN = '^New topic [0-9a-f]{20}$';
-
-// Mirrors what php/pages/supprtopic.php does, because posting a topic touches
-// more than mktopics/mkmessages: newtopic.php also follows the topic for its
-// author and bumps mkprofiles.nbmessages. Deleting only the two obvious tables
-// leaves an orphaned mkfollowers row and inflates the poster's message count by
-// one on every run. The page itself is not reusable here - it is a CSRF-guarded
-// HTML page rather than an API endpoint - so the cascade is reproduced instead.
-async function cleanupTopics() {
-  const topics: any = await sql('SELECT id FROM mktopics WHERE titre REGEXP ?', [TOPIC_PATTERN]);
-  if (!topics.length) return;
-  const ids = topics.map((t: any) => t.id);
-
-  // Before the messages go, so the per-author counts are still there to subtract.
-  // nbmessages is `int unsigned`, and MariaDB evaluates the subtraction before
-  // GREATEST: without the CAST an underflow raises ER_DATA_OUT_OF_RANGE instead
-  // of flooring at 0, turning a stale count into a hard failure of the hook.
-  await sql(
-    `UPDATE mkprofiles p
-     JOIN (SELECT auteur, COUNT(*) AS nb FROM mkmessages WHERE topic IN (?) GROUP BY auteur) c
-       ON c.auteur = p.id
-     SET p.nbmessages = GREATEST(CAST(p.nbmessages AS SIGNED) - c.nb, 0)`,
-    [ids]
-  );
-  await sql('DELETE FROM mkfollowers WHERE topic IN (?)', [ids]);
-  await sql('DELETE FROM mkmessages WHERE topic IN (?)', [ids]);
-  await sql('DELETE FROM mktopics WHERE id IN (?)', [ids]);
-  for (const table of ['mkreactions', 'mkreports', 'mkreportshist'])
-    await sql(
-      'DELETE FROM `' + table + '` WHERE type = "topic" AND SUBSTRING_INDEX(link, ",", 1) IN (?)',
-      [ids]
-    );
-  // Goes further than supprtopic.php, which leaves these behind: newtopic.php
-  // notifies every follower of the poster, and the seeded Wargor account has 386
-  // of them, so each run buried 386 rows pointing at a topic about to be deleted.
-  // That was the single largest leak in the suite.
-  await sql(
-    `DELETE FROM mknotifs
-     WHERE type IN ('follower_topic', 'forum_mention', 'forum_quote')
-       AND SUBSTRING_INDEX(link, ',', 1) IN (?)`,
-    [ids]
-  );
-}
-
-// Serial for the same reason as the other specs that install cleanup hooks:
-// beforeAll/afterAll run once per worker, and cleanupTopics deletes every topic
-// matching the pattern, not just this worker's. One test makes that moot today,
-// but a second one added under fullyParallel would race without this.
-test.describe.configure({ mode: 'serial' });
-
-// afterAll is the contract, beforeAll is what protects this run: a killed run
-// never reaches afterAll, and that is exactly when leftovers are created.
-test.beforeAll(cleanupTopics);
-test.afterAll(cleanupTopics);
+// Named so tests/global-cleanup.ts recognises and removes it afterwards.
+const TOPIC_NAME = newTopicName();
+const TOPIC_CONTENT = "New topic content " + randomBytes(10).toString('hex');
 
 test('logging in and creating a new topic', async ({ page }) => {
   // Log in

--- a/tests/forum.spec.ts
+++ b/tests/forum.spec.ts
@@ -16,9 +16,33 @@ const TOPIC_CONTENT = "New topic content " + RANDOM_ID;
 // touching a real topic that merely starts with "New topic".
 const TOPIC_PATTERN = '^New topic [0-9a-f]{20}$';
 
+// Mirrors what php/pages/supprtopic.php does, because posting a topic touches
+// more than mktopics/mkmessages: newtopic.php also follows the topic for its
+// author and bumps mkprofiles.nbmessages. Deleting only the two obvious tables
+// leaves an orphaned mkfollowers row and inflates the poster's message count by
+// one on every run. The page itself is not reusable here - it is a CSRF-guarded
+// HTML page rather than an API endpoint - so the cascade is reproduced instead.
 async function cleanupTopics() {
-  await sql('DELETE m FROM mkmessages m JOIN mktopics t ON t.id = m.topic WHERE t.titre REGEXP ?', [TOPIC_PATTERN]);
-  await sql('DELETE FROM mktopics WHERE titre REGEXP ?', [TOPIC_PATTERN]);
+  const topics: any = await sql('SELECT id FROM mktopics WHERE titre REGEXP ?', [TOPIC_PATTERN]);
+  if (!topics.length) return;
+  const ids = topics.map((t: any) => t.id);
+
+  // Before the messages go, so the per-author counts are still there to subtract.
+  await sql(
+    `UPDATE mkprofiles p
+     JOIN (SELECT auteur, COUNT(*) AS nb FROM mkmessages WHERE topic IN (?) GROUP BY auteur) c
+       ON c.auteur = p.id
+     SET p.nbmessages = GREATEST(p.nbmessages - c.nb, 0)`,
+    [ids]
+  );
+  await sql('DELETE FROM mkfollowers WHERE topic IN (?)', [ids]);
+  await sql('DELETE FROM mkmessages WHERE topic IN (?)', [ids]);
+  await sql('DELETE FROM mktopics WHERE id IN (?)', [ids]);
+  for (const table of ['mkreactions', 'mkreports', 'mkreportshist'])
+    await sql(
+      'DELETE FROM `' + table + '` WHERE type = "topic" AND SUBSTRING_INDEX(link, ",", 1) IN (?)',
+      [ids]
+    );
 }
 
 // afterAll is the contract, beforeAll is what protects this run: a killed run

--- a/tests/forum.spec.ts
+++ b/tests/forum.spec.ts
@@ -28,11 +28,14 @@ async function cleanupTopics() {
   const ids = topics.map((t: any) => t.id);
 
   // Before the messages go, so the per-author counts are still there to subtract.
+  // nbmessages is `int unsigned`, and MariaDB evaluates the subtraction before
+  // GREATEST: without the CAST an underflow raises ER_DATA_OUT_OF_RANGE instead
+  // of flooring at 0, turning a stale count into a hard failure of the hook.
   await sql(
     `UPDATE mkprofiles p
      JOIN (SELECT auteur, COUNT(*) AS nb FROM mkmessages WHERE topic IN (?) GROUP BY auteur) c
        ON c.auteur = p.id
-     SET p.nbmessages = GREATEST(p.nbmessages - c.nb, 0)`,
+     SET p.nbmessages = GREATEST(CAST(p.nbmessages AS SIGNED) - c.nb, 0)`,
     [ids]
   );
   await sql('DELETE FROM mkfollowers WHERE topic IN (?)', [ids]);
@@ -43,7 +46,23 @@ async function cleanupTopics() {
       'DELETE FROM `' + table + '` WHERE type = "topic" AND SUBSTRING_INDEX(link, ",", 1) IN (?)',
       [ids]
     );
+  // Goes further than supprtopic.php, which leaves these behind: newtopic.php
+  // notifies every follower of the poster, and the seeded Wargor account has 386
+  // of them, so each run buried 386 rows pointing at a topic about to be deleted.
+  // That was the single largest leak in the suite.
+  await sql(
+    `DELETE FROM mknotifs
+     WHERE type IN ('follower_topic', 'forum_mention', 'forum_quote')
+       AND SUBSTRING_INDEX(link, ',', 1) IN (?)`,
+    [ids]
+  );
 }
+
+// Serial for the same reason as the other specs that install cleanup hooks:
+// beforeAll/afterAll run once per worker, and cleanupTopics deletes every topic
+// matching the pattern, not just this worker's. One test makes that moot today,
+// but a second one added under fullyParallel would race without this.
+test.describe.configure({ mode: 'serial' });
 
 // afterAll is the contract, beforeAll is what protects this run: a killed run
 // never reaches afterAll, and that is exactly when leftovers are created.

--- a/tests/forum.spec.ts
+++ b/tests/forum.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { randomBytes } from 'crypto';
+import { sql } from './helpers/db';
 
 const ADMIN_USER = 'wargor';
 const ADMIN_PASSWORD = 'aaaa';
@@ -8,6 +9,22 @@ const ADMIN_USERNAME_PRINTED = "Wargor";
 const RANDOM_ID = randomBytes(10).toString('hex');
 const TOPIC_NAME = "New topic " + RANDOM_ID;
 const TOPIC_CONTENT = "New topic content " + RANDOM_ID;
+
+// Each run posts a topic under a fresh random suffix, so cleanup matches the
+// shape of the generated title rather than one run's value: it clears this run's
+// topic and any left behind by earlier ones. The anchored regexp keeps it from
+// touching a real topic that merely starts with "New topic".
+const TOPIC_PATTERN = '^New topic [0-9a-f]{20}$';
+
+async function cleanupTopics() {
+  await sql('DELETE m FROM mkmessages m JOIN mktopics t ON t.id = m.topic WHERE t.titre REGEXP ?', [TOPIC_PATTERN]);
+  await sql('DELETE FROM mktopics WHERE titre REGEXP ?', [TOPIC_PATTERN]);
+}
+
+// afterAll is the contract, beforeAll is what protects this run: a killed run
+// never reaches afterAll, and that is exactly when leftovers are created.
+test.beforeAll(cleanupTopics);
+test.afterAll(cleanupTopics);
 
 test('logging in and creating a new topic', async ({ page }) => {
   // Log in

--- a/tests/global-cleanup.ts
+++ b/tests/global-cleanup.ts
@@ -1,0 +1,23 @@
+import { FullConfig } from '@playwright/test';
+import { cleanupCreations } from './helpers/mkpc';
+import { cleanupTopics } from './helpers/forum';
+
+// Runs once before the suite and once after it, outside every worker.
+//
+// Cleanup used to live in per-spec beforeAll/afterAll hooks, which was the wrong
+// place for it twice over: those hooks run once per *worker*, so a worker
+// finishing early would delete fixtures another worker was still using, and the
+// only way to prevent that was to make each spec serial - paying for cleanup with
+// the suite's parallelism. Here nothing else is running, so neither applies.
+//
+// Both ends are wired up on purpose. afterAll is the contract; the before pass is
+// what protects this run, because a killed run never reaches the after pass, and
+// that is exactly when leftovers get created. Each sweep clears everything in its
+// scope rather than what this run happens to have made, so an interrupted run is
+// repaired by the next one instead of poisoning it.
+export default async function globalCleanup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL;
+  if (!baseURL) throw new Error('cleanup needs a baseURL: set use.baseURL or BASE_URL');
+  await cleanupCreations(baseURL);
+  await cleanupTopics();
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,26 +1,21 @@
 import mysql from 'mysql2/promise';
 
-// Direct DB access for test fixtures and cleanup.
+// Direct DB access for test fixtures and cleanup. docker-compose.yml publishes
+// MariaDB on 8306 both locally and in CI, so tests can tidy up after themselves
+// without exposing a reset endpoint on the site.
 //
-// docker-compose.yml publishes MariaDB on 8306 both locally and in CI, so tests
-// can tidy up after themselves without exposing a reset endpoint on the site.
-// Every value is overridable, mirroring how playwright.config.ts handles BASE_URL.
+// MKPC_-prefixed rather than the bare DB_HOST / DB_USER names, because this module
+// only ever issues DELETEs and those generic names are already in use for other
+// databases (see the migration rule in CLAUDE.md).
 //
-// The variables are MKPC_DB_*-prefixed rather than the bare DB_HOST / DB_USER
-// names: this module only ever issues DELETEs, and those generic names are
-// already in use for other databases (see the migration rule in CLAUDE.md), so
-// an unrelated export in the shell must not be able to redirect them.
-//
-// Note for multi-worktree setups: sibling checkouts share one MariaDB container
-// on 8306 while each gets its own web port. Owner tags are per spec file, not
-// per checkout, so two worktrees running the suite at the same time will clean
-// up each other's fixtures. Run one suite at a time, or point MKPC_DB_PORT and
-// BASE_URL at a dedicated stack.
+// Sibling worktrees share one MariaDB container while each gets its own web port,
+// and owner tags are per spec file rather than per checkout - so running the suite
+// in two checkouts at once makes them clean up each other's fixtures.
 const config = {
   host: process.env.MKPC_DB_HOST || '127.0.0.1',
   port: Number(process.env.MKPC_DB_PORT || 8306),
-  user: process.env.MKPC_DB_USER || 'root',
-  password: process.env.MKPC_DB_PASSWORD || 'root',
+  user: process.env.MKPC_DB_USER || 'mkpc_user',
+  password: process.env.MKPC_DB_PASSWORD || 'mkpc_pwd',
   database: process.env.MKPC_DB_NAME || 'mkpc',
   multipleStatements: false,
 };

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,29 @@
+import mysql from 'mysql2/promise';
+
+// Direct DB access for test fixtures and cleanup.
+//
+// docker-compose.yml publishes MariaDB on 8306 both locally and in CI, so tests
+// can tidy up after themselves without exposing a reset endpoint on the site.
+// Every value is overridable, mirroring how playwright.config.ts handles BASE_URL.
+const config = {
+  host: process.env.DB_HOST || '127.0.0.1',
+  port: Number(process.env.DB_PORT || 8306),
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || 'root',
+  database: process.env.DB_NAME || 'mkpc',
+  multipleStatements: false,
+};
+
+// A fresh connection per call: cleanup runs a handful of times per file, and a
+// pool would keep the Playwright process alive after the last test.
+export async function sql(query: string, params: any[] = []): Promise<any> {
+  const conn = await mysql.createConnection(config);
+  try {
+    // query() rather than execute(): prepared statements cannot expand an array
+    // into an IN (?) list, which the scope-based cleanups rely on.
+    const [rows] = await conn.query(query, params);
+    return rows;
+  } finally {
+    await conn.end();
+  }
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -5,12 +5,23 @@ import mysql from 'mysql2/promise';
 // docker-compose.yml publishes MariaDB on 8306 both locally and in CI, so tests
 // can tidy up after themselves without exposing a reset endpoint on the site.
 // Every value is overridable, mirroring how playwright.config.ts handles BASE_URL.
+//
+// The variables are MKPC_DB_*-prefixed rather than the bare DB_HOST / DB_USER
+// names: this module only ever issues DELETEs, and those generic names are
+// already in use for other databases (see the migration rule in CLAUDE.md), so
+// an unrelated export in the shell must not be able to redirect them.
+//
+// Note for multi-worktree setups: sibling checkouts share one MariaDB container
+// on 8306 while each gets its own web port. Owner tags are per spec file, not
+// per checkout, so two worktrees running the suite at the same time will clean
+// up each other's fixtures. Run one suite at a time, or point MKPC_DB_PORT and
+// BASE_URL at a dedicated stack.
 const config = {
-  host: process.env.DB_HOST || '127.0.0.1',
-  port: Number(process.env.DB_PORT || 8306),
-  user: process.env.DB_USER || 'root',
-  password: process.env.DB_PASSWORD || 'root',
-  database: process.env.DB_NAME || 'mkpc',
+  host: process.env.MKPC_DB_HOST || '127.0.0.1',
+  port: Number(process.env.MKPC_DB_PORT || 8306),
+  user: process.env.MKPC_DB_USER || 'root',
+  password: process.env.MKPC_DB_PASSWORD || 'root',
+  database: process.env.MKPC_DB_NAME || 'mkpc',
   multipleStatements: false,
 };
 
@@ -20,7 +31,7 @@ export async function sql(query: string, params: any[] = []): Promise<any> {
   const conn = await mysql.createConnection(config);
   try {
     // query() rather than execute(): prepared statements cannot expand an array
-    // into an IN (?) list, which the scope-based cleanups rely on.
+    // into an IN (?) list, which the cleanups use to delete a batch of ids.
     const [rows] = await conn.query(query, params);
     return rows;
   } finally {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -9,8 +9,8 @@ import mysql from 'mysql2/promise';
 // databases (see the migration rule in CLAUDE.md).
 //
 // Sibling worktrees share one MariaDB container while each gets its own web port,
-// and owner tags are per spec file rather than per checkout - so running the suite
-// in two checkouts at once makes them clean up each other's fixtures.
+// and the cleanup scope is a name prefix rather than a checkout - so running the
+// suite in two checkouts at once makes them clean up each other's fixtures.
 const config = {
   host: process.env.MKPC_DB_HOST || '127.0.0.1',
   port: Number(process.env.MKPC_DB_PORT || 8306),

--- a/tests/helpers/forum.ts
+++ b/tests/helpers/forum.ts
@@ -1,0 +1,49 @@
+import { randomBytes } from 'crypto';
+import { sql } from './db';
+
+// Topics are named with a random suffix, and cleanup matches the *shape* of that
+// name rather than one run's value, so it clears this run's topic and any left
+// behind by an earlier one. Anchored, so a real topic that merely starts with
+// "New topic" is never matched.
+const TOPIC_PATTERN = '^New topic [0-9a-f]{20}$';
+
+export function newTopicName(): string {
+  return 'New topic ' + randomBytes(10).toString('hex');
+}
+
+// Mirrors php/pages/supprtopic.php, because posting a topic touches more than
+// mktopics/mkmessages: newtopic.php also follows the topic for its author and
+// bumps mkprofiles.nbmessages. supprtopic.php is a CSRF-guarded HTML page rather
+// than an API endpoint, so the cascade is reproduced instead of called.
+export async function cleanupTopics() {
+  const topics: any = await sql('SELECT id FROM mktopics WHERE titre REGEXP ?', [TOPIC_PATTERN]);
+  if (!topics.length) return;
+  const ids = topics.map((t: any) => t.id);
+
+  // Before the messages go, so the per-author counts are still there to subtract.
+  // nbmessages is `int unsigned` and MariaDB evaluates the subtraction before
+  // GREATEST, so without the CAST an underflow errors instead of flooring at 0.
+  await sql(
+    `UPDATE mkprofiles p
+     JOIN (SELECT auteur, COUNT(*) AS nb FROM mkmessages WHERE topic IN (?) GROUP BY auteur) c
+       ON c.auteur = p.id
+     SET p.nbmessages = GREATEST(CAST(p.nbmessages AS SIGNED) - c.nb, 0)`,
+    [ids]
+  );
+  await sql('DELETE FROM mkfollowers WHERE topic IN (?)', [ids]);
+  await sql('DELETE FROM mkmessages WHERE topic IN (?)', [ids]);
+  await sql('DELETE FROM mktopics WHERE id IN (?)', [ids]);
+  for (const table of ['mkreactions', 'mkreports', 'mkreportshist'])
+    await sql(
+      'DELETE FROM `' + table + '` WHERE type = "topic" AND SUBSTRING_INDEX(link, ",", 1) IN (?)',
+      [ids]
+    );
+  // Goes further than supprtopic.php, which leaves these behind: newtopic.php
+  // notifies every follower of the poster, and the seeded account has 386 of them.
+  await sql(
+    `DELETE FROM mknotifs
+     WHERE type IN ('follower_topic', 'forum_mention', 'forum_quote')
+       AND SUBSTRING_INDEX(link, ',', 1) IN (?)`,
+    [ids]
+  );
+}

--- a/tests/helpers/mkpc.ts
+++ b/tests/helpers/mkpc.ts
@@ -18,46 +18,74 @@ const ADMIN_PASSWORD = 'aaaa';
 export const SIMPLE_CIRCUIT_PIECES =
   '11,5,4,5,9,4,11,8,8,8,5,7,11,8,8,8,6,4,11,8,6,7,11,2,5,7,11,11,11,8,6,9,9,9,9,7'.split(',');
 
-// Default owner tag. Each spec file passes its OWN tag: spec files run in
-// parallel workers, so a cleanup scoped to a tag shared between files would
-// delete another file's fixtures while it is still using them.
-export const TEST_AUTHOR = 'e2e-mc-bot';
+// The site the cleanup posts to. Taken from the Playwright config so it cannot
+// drift from the one the tests themselves use — setting `use.baseURL` in the
+// config instead of via BASE_URL is supported, and a cleanup pointed at another
+// host would silently delete nothing.
+function cleanupBaseURL(): string {
+  const configured = test.info().project.use.baseURL;
+  if (!configured) throw new Error('cleanup needs a baseURL: set use.baseURL or BASE_URL');
+  return configured;
+}
 
-// Removes every creation owned by the e2e bot, whether this run or an earlier one
+// Removes every creation owned by `author`, whether this run or an earlier one
 // made it, so a crashed run is healed instead of leaving fixtures behind forever.
+//
+// `author` is required rather than defaulted: spec files run in parallel workers,
+// so a cleanup scoped to a tag shared between files would delete another file's
+// fixtures while it is still using them. Requiring it surfaces a forgotten tag as
+// a type error rather than as a race that only shows up under load.
 //
 // Deletion goes through supprCreation.php rather than raw SQL on purpose: the
 // endpoint cascades to cups, orphaned multicups, records, ghosts and challenge
 // references, and unlinks the track thumbnail from disk (postCircuitDelete).
 // Reproducing that in SQL would leak rows and files on every schema change.
-export async function cleanupCreations(author: string = TEST_AUTHOR) {
+export async function cleanupCreations(author: string) {
   const circuits: any = await sql('SELECT id FROM mkcircuits WHERE auteur = ?', [author]);
   if (circuits.length) {
-    const ctx = await apiRequest.newContext({
-      baseURL: process.env.BASE_URL || 'http://127.0.0.1:8080',
-    });
-    // Wargor holds "admin", which getUserRights expands to "moderator", so the
-    // ownership check in supprCreation.php is satisfied regardless of which
-    // browser identity originally created the track.
-    await ctx.post('/api/testcode.php', { form: { pseudo: ADMIN_USER, code: ADMIN_PASSWORD } });
-    // Deleted in batches: a first run against a database with a large backlog
-    // would otherwise spend minutes on sequential round-trips.
-    const ids = circuits.map((c: any) => String(c.id));
-    const CONCURRENCY = 10;
-    for (let i = 0; i < ids.length; i += CONCURRENCY) {
-      await Promise.all(
-        ids.slice(i, i + CONCURRENCY).map((id: string) =>
-          ctx.post('/api/supprCreation.php', { form: { id, collab: '' } })
-        )
-      );
+    const ctx = await apiRequest.newContext({ baseURL: cleanupBaseURL() });
+    try {
+      // Wargor holds "admin", which getUserRights expands to "moderator", so the
+      // ownership check in supprCreation.php is satisfied regardless of which
+      // browser identity originally created the track.
+      //
+      // The response is checked because testcode.php answers "0" on a failed
+      // login while supprCreation.php echoes "1" even when it matched no row.
+      // Unverified, the whole cleanup would no-op silently and the suite would
+      // still pass while the leak this exists to stop carried on.
+      const auth = await ctx.post('/api/testcode.php', { form: { pseudo: ADMIN_USER, code: ADMIN_PASSWORD } });
+      const adminId = Number((await auth.text()).trim());
+      if (!(adminId > 0))
+        throw new Error(
+          'cleanup could not log in as ' + ADMIN_USER + ' (testcode.php returned "' + adminId + '"). ' +
+          'Check the seeded credentials and that baseURL points at the site under test.'
+        );
+      // Deleted in batches: a first run against a database with a large backlog
+      // would otherwise spend minutes on sequential round-trips (measured over 40
+      // deletes: 144ms one at a time, 32ms batched at 10).
+      const ids = circuits.map((c: any) => String(c.id));
+      const CONCURRENCY = 10;
+      for (let i = 0; i < ids.length; i += CONCURRENCY) {
+        await Promise.all(
+          ids.slice(i, i + CONCURRENCY).map((id: string) =>
+            ctx.post('/api/supprCreation.php', { form: { id, collab: '' } })
+          )
+        );
+      }
+    } finally {
+      await ctx.dispose();
     }
-    await ctx.dispose();
   }
   // Cups and multicups whose tracks were already gone are never reached by the
   // cascade above, so sweep them by the same author scope.
   await sql('DELETE t FROM mkmcups_tracks t JOIN mkmcups m ON m.id = t.mcup WHERE m.auteur = ?', [author]);
   await sql('DELETE FROM mkmcups WHERE auteur = ?', [author]);
   await sql('DELETE FROM mkcups WHERE auteur = ?', [author]);
+  // The endpoint reports success even when it deleted nothing, so confirm the
+  // scope is actually empty rather than trusting the responses above.
+  const left: any = await sql('SELECT COUNT(*) AS n FROM mkcircuits WHERE auteur = ?', [author]);
+  if (Number(left[0].n))
+    throw new Error('cleanup left ' + left[0].n + ' circuit(s) owned by ' + author);
 }
 
 // Installs the cleanup hooks for a spec that builds creations. Call it at the top
@@ -67,7 +95,7 @@ export async function cleanupCreations(author: string = TEST_AUTHOR) {
 // afterAll is the contract, beforeAll is what protects this run - a killed run
 // never reaches afterAll, and that is exactly when leftovers get created. The
 // raised timeout only matters the first time, when clearing an existing backlog.
-export function useCreationCleanup(author: string = TEST_AUTHOR) {
+export function useCreationCleanup(author: string) {
   const run = async () => {
     test.setTimeout(120_000);
     await cleanupCreations(author);
@@ -102,11 +130,11 @@ async function postInt(request: APIRequestContext, url: string, form: Record<str
 // have no such limit.
 export async function createCircuit(
   request: APIRequestContext,
-  opts: { name?: string; map?: string; laps?: string; author?: string } = {}
+  opts: { author: string; name?: string; map?: string; laps?: string }
 ): Promise<number> {
   const form: Record<string, string> = {
     nom: opts.name ?? 'e2e-circuit',
-    auteur: opts.author ?? TEST_AUTHOR,
+    auteur: opts.author,
     map: opts.map ?? '1',
     nl: opts.laps ?? '3',
   };
@@ -125,7 +153,7 @@ export async function createCircuit(
 // caller can always index [0..count). A multicup only needs cups, and a cup
 // accepts the same circuit in several slots, so one circuit is enough to build
 // an arbitrarily large multicup.
-export async function createCircuits(request: APIRequestContext, count: number, author: string = TEST_AUTHOR): Promise<number[]> {
+export async function createCircuits(request: APIRequestContext, count: number, author: string): Promise<number[]> {
   const ids: number[] = [];
   for (let i = 0; i < count; i++) {
     try {
@@ -143,9 +171,9 @@ export async function createCircuits(request: APIRequestContext, count: number, 
 // Creates a simple-mode cup (mode 0) referencing 4 circuit slots. Returns its id.
 export async function createCup(
   request: APIRequestContext,
-  opts: { name: string; circuitIds: number[]; options?: object; author?: string }
+  opts: { name: string; circuitIds: number[]; author: string; options?: object }
 ): Promise<number> {
-  const form: Record<string, string> = { nom: opts.name, auteur: opts.author ?? TEST_AUTHOR, mode: '0' };
+  const form: Record<string, string> = { nom: opts.name, auteur: opts.author, mode: '0' };
   for (let i = 0; i < 4; i++) form['cid' + i] = String(opts.circuitIds[i % opts.circuitIds.length]);
   if (opts.options) form.opt = JSON.stringify(opts.options);
   const id = await postInt(request, '/api/saveCup.php', form);
@@ -157,9 +185,9 @@ export async function createCup(
 // holds the multicup appearance config (icons / lines / pages / persos).
 export async function createMulticup(
   request: APIRequestContext,
-  opts: { name: string; cupIds: number[]; options?: object; author?: string }
+  opts: { name: string; cupIds: number[]; author: string; options?: object }
 ): Promise<number> {
-  const form: Record<string, string> = { nom: opts.name, auteur: opts.author ?? TEST_AUTHOR, mode: '0' };
+  const form: Record<string, string> = { nom: opts.name, auteur: opts.author, mode: '0' };
   opts.cupIds.forEach((id, i) => (form['cid' + i] = String(id)));
   if (opts.options) form.opt = JSON.stringify(opts.options);
   const id = await postInt(request, '/api/saveMCup.php', form);

--- a/tests/helpers/mkpc.ts
+++ b/tests/helpers/mkpc.ts
@@ -1,4 +1,4 @@
-import { Page, APIRequestContext, expect, test, request as apiRequest } from '@playwright/test';
+import { Page, APIRequestContext, expect, request as apiRequest } from '@playwright/test';
 import { sql } from './db';
 
 // Shared helpers for end-to-end tests that build their own creations
@@ -18,13 +18,9 @@ const ADMIN_PASSWORD = 'aaaa';
 export const SIMPLE_CIRCUIT_PIECES =
   '11,5,4,5,9,4,11,8,8,8,5,7,11,8,8,8,6,4,11,8,6,7,11,2,5,7,11,11,11,8,6,9,9,9,9,7'.split(',');
 
-// Read from the Playwright config rather than the environment, so cleanup cannot
-// target a different site than the tests when baseURL is set in the config.
-function cleanupBaseURL(): string {
-  const configured = test.info().project.use.baseURL;
-  if (!configured) throw new Error('cleanup needs a baseURL: set use.baseURL or BASE_URL');
-  return configured;
-}
+// Every author tag a spec creates under must match this, or its fixtures survive
+// the sweep in tests/global-cleanup.ts.
+const TEST_AUTHOR_PATTERN = 'e2e-%';
 
 // saveCreation/saveCup/saveMCup each notify every follower of the poster, and no
 // delete path removes those rows. The prefix in `link` identifies the kind of
@@ -37,22 +33,27 @@ async function deleteFollowerNotifs(kind: keyof typeof NOTIF_PREFIX, ids: string
     [ids.map((id) => NOTIF_PREFIX[kind] + ',' + id)]);
 }
 
-// Removes every creation owned by `author`, whether this run or an earlier one
-// made it, so a crashed run is healed instead of leaving fixtures behind forever.
-// `author` is required so that a spec file cannot silently share another's scope.
+// Removes every creation whose author matches TEST_AUTHOR_PATTERN, whether this
+// run or an earlier one made it, so a crashed run is healed instead of leaving
+// fixtures behind forever.
+//
+// Matching a pattern rather than a list of owners is what keeps this out of the
+// spec files: a new spec only has to tag its creations `e2e-*` to be cleaned up,
+// with nothing to register here.
 //
 // Circuits go through supprCreation.php rather than raw SQL: the endpoint cascades
 // to cups, orphaned multicups, records, ghosts and challenge references, and
 // unlinks the track thumbnail from disk (postCircuitDelete).
-export async function cleanupCreations(author: string) {
+export async function cleanupCreations(baseURL: string) {
   const scope = async (table: string): Promise<string[]> =>
-    (await sql('SELECT id FROM `' + table + '` WHERE auteur = ?', [author])).map((r: any) => String(r.id));
+    (await sql('SELECT id FROM `' + table + '` WHERE auteur LIKE ?', [TEST_AUTHOR_PATTERN]))
+      .map((r: any) => String(r.id));
   const circuits = await scope('mkcircuits');
   const cups = await scope('mkcups');
   const mcups = await scope('mkmcups');
 
   if (circuits.length) {
-    const ctx = await apiRequest.newContext({ baseURL: cleanupBaseURL() });
+    const ctx = await apiRequest.newContext({ baseURL });
     try {
       // Wargor holds "admin", which getUserRights expands to "moderator", so the
       // ownership check in supprCreation.php passes whichever browser identity
@@ -80,9 +81,10 @@ export async function cleanupCreations(author: string) {
   }
   // Cups and multicups whose tracks were already gone are never reached by the
   // cascade above, so sweep them by the same author scope.
-  await sql('DELETE t FROM mkmcups_tracks t JOIN mkmcups m ON m.id = t.mcup WHERE m.auteur = ?', [author]);
-  await sql('DELETE FROM mkmcups WHERE auteur = ?', [author]);
-  await sql('DELETE FROM mkcups WHERE auteur = ?', [author]);
+  const p = TEST_AUTHOR_PATTERN;
+  await sql('DELETE t FROM mkmcups_tracks t JOIN mkmcups m ON m.id = t.mcup WHERE m.auteur LIKE ?', [p]);
+  await sql('DELETE FROM mkmcups WHERE auteur LIKE ?', [p]);
+  await sql('DELETE FROM mkcups WHERE auteur LIKE ?', [p]);
   await deleteFollowerNotifs('circuits', circuits);
   await deleteFollowerNotifs('cups', cups);
   await deleteFollowerNotifs('mcups', mcups);
@@ -90,31 +92,14 @@ export async function cleanupCreations(author: string) {
   // supprCreation.php echoes success even when it matched no row, so verify.
   const left: any = await sql(
     `SELECT
-       (SELECT COUNT(*) FROM mkcircuits WHERE auteur = ?) AS circuits,
-       (SELECT COUNT(*) FROM mkcups     WHERE auteur = ?) AS cups,
-       (SELECT COUNT(*) FROM mkmcups    WHERE auteur = ?) AS mcups`,
-    [author, author, author]
+       (SELECT COUNT(*) FROM mkcircuits WHERE auteur LIKE ?) AS circuits,
+       (SELECT COUNT(*) FROM mkcups     WHERE auteur LIKE ?) AS cups,
+       (SELECT COUNT(*) FROM mkmcups    WHERE auteur LIKE ?) AS mcups`,
+    [p, p, p]
   );
   const remaining = Object.entries(left[0]).filter(([, n]) => Number(n) > 0);
   if (remaining.length)
-    throw new Error(
-      'cleanup left ' + remaining.map(([t, n]) => n + ' ' + t).join(', ') + ' owned by ' + author
-    );
-}
-
-// Installs the cleanup hooks for a spec that builds creations. Must be called from
-// a serial scope: beforeAll/afterAll run once per worker, so under fullyParallel a
-// worker finishing early would delete fixtures another worker is still using.
-//
-// afterAll is the contract, beforeAll is what protects this run - a killed run
-// never reaches afterAll, and that is exactly when leftovers get created.
-export function useCreationCleanup(author: string) {
-  const run = async () => {
-    test.setTimeout(120_000);
-    await cleanupCreations(author);
-  };
-  test.beforeAll(run);
-  test.afterAll(run);
+    throw new Error('cleanup left ' + remaining.map(([t, n]) => n + ' ' + t).join(', '));
 }
 
 export async function login(page: Page) {

--- a/tests/helpers/mkpc.ts
+++ b/tests/helpers/mkpc.ts
@@ -1,4 +1,5 @@
-import { Page, APIRequestContext, expect } from '@playwright/test';
+import { Page, APIRequestContext, expect, test, request as apiRequest } from '@playwright/test';
+import { sql } from './db';
 
 // Shared helpers for end-to-end tests that build their own creations
 // (circuits -> cups -> multicup) and then play them.
@@ -17,7 +18,63 @@ const ADMIN_PASSWORD = 'aaaa';
 export const SIMPLE_CIRCUIT_PIECES =
   '11,5,4,5,9,4,11,8,8,8,5,7,11,8,8,8,6,4,11,8,6,7,11,2,5,7,11,11,11,8,6,9,9,9,9,7'.split(',');
 
-const TEST_AUTHOR = 'e2e-mc-bot';
+// Default owner tag. Each spec file passes its OWN tag: spec files run in
+// parallel workers, so a cleanup scoped to a tag shared between files would
+// delete another file's fixtures while it is still using them.
+export const TEST_AUTHOR = 'e2e-mc-bot';
+
+// Removes every creation owned by the e2e bot, whether this run or an earlier one
+// made it, so a crashed run is healed instead of leaving fixtures behind forever.
+//
+// Deletion goes through supprCreation.php rather than raw SQL on purpose: the
+// endpoint cascades to cups, orphaned multicups, records, ghosts and challenge
+// references, and unlinks the track thumbnail from disk (postCircuitDelete).
+// Reproducing that in SQL would leak rows and files on every schema change.
+export async function cleanupCreations(author: string = TEST_AUTHOR) {
+  const circuits: any = await sql('SELECT id FROM mkcircuits WHERE auteur = ?', [author]);
+  if (circuits.length) {
+    const ctx = await apiRequest.newContext({
+      baseURL: process.env.BASE_URL || 'http://127.0.0.1:8080',
+    });
+    // Wargor holds "admin", which getUserRights expands to "moderator", so the
+    // ownership check in supprCreation.php is satisfied regardless of which
+    // browser identity originally created the track.
+    await ctx.post('/api/testcode.php', { form: { pseudo: ADMIN_USER, code: ADMIN_PASSWORD } });
+    // Deleted in batches: a first run against a database with a large backlog
+    // would otherwise spend minutes on sequential round-trips.
+    const ids = circuits.map((c: any) => String(c.id));
+    const CONCURRENCY = 10;
+    for (let i = 0; i < ids.length; i += CONCURRENCY) {
+      await Promise.all(
+        ids.slice(i, i + CONCURRENCY).map((id: string) =>
+          ctx.post('/api/supprCreation.php', { form: { id, collab: '' } })
+        )
+      );
+    }
+    await ctx.dispose();
+  }
+  // Cups and multicups whose tracks were already gone are never reached by the
+  // cascade above, so sweep them by the same author scope.
+  await sql('DELETE t FROM mkmcups_tracks t JOIN mkmcups m ON m.id = t.mcup WHERE m.auteur = ?', [author]);
+  await sql('DELETE FROM mkmcups WHERE auteur = ?', [author]);
+  await sql('DELETE FROM mkcups WHERE auteur = ?', [author]);
+}
+
+// Installs the cleanup hooks for a spec that builds creations. Call it at the top
+// of the file: the spec still declares that it owns this cleanup, but without
+// repeating the hook/timeout boilerplate.
+//
+// afterAll is the contract, beforeAll is what protects this run - a killed run
+// never reaches afterAll, and that is exactly when leftovers get created. The
+// raised timeout only matters the first time, when clearing an existing backlog.
+export function useCreationCleanup(author: string = TEST_AUTHOR) {
+  const run = async () => {
+    test.setTimeout(120_000);
+    await cleanupCreations(author);
+  };
+  test.beforeAll(run);
+  test.afterAll(run);
+}
 
 export async function login(page: Page) {
   await page.goto('/');
@@ -45,11 +102,11 @@ async function postInt(request: APIRequestContext, url: string, form: Record<str
 // have no such limit.
 export async function createCircuit(
   request: APIRequestContext,
-  opts: { name?: string; map?: string; laps?: string } = {}
+  opts: { name?: string; map?: string; laps?: string; author?: string } = {}
 ): Promise<number> {
   const form: Record<string, string> = {
     nom: opts.name ?? 'e2e-circuit',
-    auteur: TEST_AUTHOR,
+    auteur: opts.author ?? TEST_AUTHOR,
     map: opts.map ?? '1',
     nl: opts.laps ?? '3',
   };
@@ -68,11 +125,11 @@ export async function createCircuit(
 // caller can always index [0..count). A multicup only needs cups, and a cup
 // accepts the same circuit in several slots, so one circuit is enough to build
 // an arbitrarily large multicup.
-export async function createCircuits(request: APIRequestContext, count: number): Promise<number[]> {
+export async function createCircuits(request: APIRequestContext, count: number, author: string = TEST_AUTHOR): Promise<number[]> {
   const ids: number[] = [];
   for (let i = 0; i < count; i++) {
     try {
-      ids.push(await createCircuit(request, { name: 'e2e-circuit-' + (i + 1) }));
+      ids.push(await createCircuit(request, { name: 'e2e-circuit-' + (i + 1), author }));
     } catch (e) {
       if (ids.length === 0) throw e; // no circuit at all -> cannot build anything
       break; // cooldown after the first: reuse what we have
@@ -86,9 +143,9 @@ export async function createCircuits(request: APIRequestContext, count: number):
 // Creates a simple-mode cup (mode 0) referencing 4 circuit slots. Returns its id.
 export async function createCup(
   request: APIRequestContext,
-  opts: { name: string; circuitIds: number[]; options?: object }
+  opts: { name: string; circuitIds: number[]; options?: object; author?: string }
 ): Promise<number> {
-  const form: Record<string, string> = { nom: opts.name, auteur: TEST_AUTHOR, mode: '0' };
+  const form: Record<string, string> = { nom: opts.name, auteur: opts.author ?? TEST_AUTHOR, mode: '0' };
   for (let i = 0; i < 4; i++) form['cid' + i] = String(opts.circuitIds[i % opts.circuitIds.length]);
   if (opts.options) form.opt = JSON.stringify(opts.options);
   const id = await postInt(request, '/api/saveCup.php', form);
@@ -100,9 +157,9 @@ export async function createCup(
 // holds the multicup appearance config (icons / lines / pages / persos).
 export async function createMulticup(
   request: APIRequestContext,
-  opts: { name: string; cupIds: number[]; options?: object }
+  opts: { name: string; cupIds: number[]; options?: object; author?: string }
 ): Promise<number> {
-  const form: Record<string, string> = { nom: opts.name, auteur: TEST_AUTHOR, mode: '0' };
+  const form: Record<string, string> = { nom: opts.name, auteur: opts.author ?? TEST_AUTHOR, mode: '0' };
   opts.cupIds.forEach((id, i) => (form['cid' + i] = String(id)));
   if (opts.options) form.opt = JSON.stringify(opts.options);
   const id = await postInt(request, '/api/saveMCup.php', form);

--- a/tests/helpers/mkpc.ts
+++ b/tests/helpers/mkpc.ts
@@ -18,56 +18,58 @@ const ADMIN_PASSWORD = 'aaaa';
 export const SIMPLE_CIRCUIT_PIECES =
   '11,5,4,5,9,4,11,8,8,8,5,7,11,8,8,8,6,4,11,8,6,7,11,2,5,7,11,11,11,8,6,9,9,9,9,7'.split(',');
 
-// The site the cleanup posts to. Taken from the Playwright config so it cannot
-// drift from the one the tests themselves use — setting `use.baseURL` in the
-// config instead of via BASE_URL is supported, and a cleanup pointed at another
-// host would silently delete nothing.
+// Read from the Playwright config rather than the environment, so cleanup cannot
+// target a different site than the tests when baseURL is set in the config.
 function cleanupBaseURL(): string {
   const configured = test.info().project.use.baseURL;
   if (!configured) throw new Error('cleanup needs a baseURL: set use.baseURL or BASE_URL');
   return configured;
 }
 
+// saveCreation/saveCup/saveMCup each notify every follower of the poster, and no
+// delete path removes those rows. The prefix in `link` identifies the kind of
+// creation: 0=circuit, 3=cup, 4=multicup.
+const NOTIF_PREFIX = { circuits: 0, cups: 3, mcups: 4 };
+
+async function deleteFollowerNotifs(kind: keyof typeof NOTIF_PREFIX, ids: string[]) {
+  if (!ids.length) return;
+  await sql('DELETE FROM mknotifs WHERE type = "follower_circuit" AND link IN (?)',
+    [ids.map((id) => NOTIF_PREFIX[kind] + ',' + id)]);
+}
+
 // Removes every creation owned by `author`, whether this run or an earlier one
 // made it, so a crashed run is healed instead of leaving fixtures behind forever.
+// `author` is required so that a spec file cannot silently share another's scope.
 //
-// `author` is required rather than defaulted: spec files run in parallel workers,
-// so a cleanup scoped to a tag shared between files would delete another file's
-// fixtures while it is still using them. Requiring it surfaces a forgotten tag as
-// a type error rather than as a race that only shows up under load.
-//
-// Deletion goes through supprCreation.php rather than raw SQL on purpose: the
-// endpoint cascades to cups, orphaned multicups, records, ghosts and challenge
-// references, and unlinks the track thumbnail from disk (postCircuitDelete).
-// Reproducing that in SQL would leak rows and files on every schema change.
+// Circuits go through supprCreation.php rather than raw SQL: the endpoint cascades
+// to cups, orphaned multicups, records, ghosts and challenge references, and
+// unlinks the track thumbnail from disk (postCircuitDelete).
 export async function cleanupCreations(author: string) {
-  const circuits: any = await sql('SELECT id FROM mkcircuits WHERE auteur = ?', [author]);
+  const scope = async (table: string): Promise<string[]> =>
+    (await sql('SELECT id FROM `' + table + '` WHERE auteur = ?', [author])).map((r: any) => String(r.id));
+  const circuits = await scope('mkcircuits');
+  const cups = await scope('mkcups');
+  const mcups = await scope('mkmcups');
+
   if (circuits.length) {
     const ctx = await apiRequest.newContext({ baseURL: cleanupBaseURL() });
     try {
       // Wargor holds "admin", which getUserRights expands to "moderator", so the
-      // ownership check in supprCreation.php is satisfied regardless of which
-      // browser identity originally created the track.
-      //
-      // The response is checked because testcode.php answers "0" on a failed
-      // login while supprCreation.php echoes "1" even when it matched no row.
-      // Unverified, the whole cleanup would no-op silently and the suite would
-      // still pass while the leak this exists to stop carried on.
+      // ownership check in supprCreation.php passes whichever browser identity
+      // originally created the track.
       const auth = await ctx.post('/api/testcode.php', { form: { pseudo: ADMIN_USER, code: ADMIN_PASSWORD } });
-      const adminId = Number((await auth.text()).trim());
-      if (!(adminId > 0))
+      const body = (await auth.text()).trim();
+      if (!(Number(body) > 0))
         throw new Error(
-          'cleanup could not log in as ' + ADMIN_USER + ' (testcode.php returned "' + adminId + '"). ' +
+          'cleanup could not log in as ' + ADMIN_USER + ' (testcode.php returned "' + body + '"). ' +
           'Check the seeded credentials and that baseURL points at the site under test.'
         );
-      // Deleted in batches: a first run against a database with a large backlog
-      // would otherwise spend minutes on sequential round-trips (measured over 40
-      // deletes: 144ms one at a time, 32ms batched at 10).
-      const ids = circuits.map((c: any) => String(c.id));
+      // Batched because a first run against an existing backlog is otherwise slow
+      // enough to exhaust the hook timeout (40 deletes: 144ms serially, 32ms here).
       const CONCURRENCY = 10;
-      for (let i = 0; i < ids.length; i += CONCURRENCY) {
+      for (let i = 0; i < circuits.length; i += CONCURRENCY) {
         await Promise.all(
-          ids.slice(i, i + CONCURRENCY).map((id: string) =>
+          circuits.slice(i, i + CONCURRENCY).map((id: string) =>
             ctx.post('/api/supprCreation.php', { form: { id, collab: '' } })
           )
         );
@@ -81,20 +83,31 @@ export async function cleanupCreations(author: string) {
   await sql('DELETE t FROM mkmcups_tracks t JOIN mkmcups m ON m.id = t.mcup WHERE m.auteur = ?', [author]);
   await sql('DELETE FROM mkmcups WHERE auteur = ?', [author]);
   await sql('DELETE FROM mkcups WHERE auteur = ?', [author]);
-  // The endpoint reports success even when it deleted nothing, so confirm the
-  // scope is actually empty rather than trusting the responses above.
-  const left: any = await sql('SELECT COUNT(*) AS n FROM mkcircuits WHERE auteur = ?', [author]);
-  if (Number(left[0].n))
-    throw new Error('cleanup left ' + left[0].n + ' circuit(s) owned by ' + author);
+  await deleteFollowerNotifs('circuits', circuits);
+  await deleteFollowerNotifs('cups', cups);
+  await deleteFollowerNotifs('mcups', mcups);
+
+  // supprCreation.php echoes success even when it matched no row, so verify.
+  const left: any = await sql(
+    `SELECT
+       (SELECT COUNT(*) FROM mkcircuits WHERE auteur = ?) AS circuits,
+       (SELECT COUNT(*) FROM mkcups     WHERE auteur = ?) AS cups,
+       (SELECT COUNT(*) FROM mkmcups    WHERE auteur = ?) AS mcups`,
+    [author, author, author]
+  );
+  const remaining = Object.entries(left[0]).filter(([, n]) => Number(n) > 0);
+  if (remaining.length)
+    throw new Error(
+      'cleanup left ' + remaining.map(([t, n]) => n + ' ' + t).join(', ') + ' owned by ' + author
+    );
 }
 
-// Installs the cleanup hooks for a spec that builds creations. Call it at the top
-// of the file: the spec still declares that it owns this cleanup, but without
-// repeating the hook/timeout boilerplate.
+// Installs the cleanup hooks for a spec that builds creations. Must be called from
+// a serial scope: beforeAll/afterAll run once per worker, so under fullyParallel a
+// worker finishing early would delete fixtures another worker is still using.
 //
 // afterAll is the contract, beforeAll is what protects this run - a killed run
-// never reaches afterAll, and that is exactly when leftovers get created. The
-// raised timeout only matters the first time, when clearing an existing backlog.
+// never reaches afterAll, and that is exactly when leftovers get created.
 export function useCreationCleanup(author: string) {
   const run = async () => {
     test.setTimeout(120_000);

--- a/tests/multicup.spec.ts
+++ b/tests/multicup.spec.ts
@@ -10,7 +10,6 @@ import {
   backToCupScreen,
   waitForTrackScreen,
   CUSTOM_ICON,
-  useCreationCleanup,
 } from './helpers/mkpc';
 
 // End-to-end coverage of the multicup flow: build a real multicup from scratch
@@ -40,11 +39,6 @@ test.describe.configure({ mode: 'serial' });
 test.describe('multicup', () => {
   let mid: number;
   let firstCupId: number;
-
-  // Clears creations left by any earlier run before building this run's fixtures,
-  // and again afterwards so a passing run leaves the database as it found it.
-  // Own owner tag, so a concurrently running spec's cleanup cannot delete these.
-  useCreationCleanup(OWNER);
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();

--- a/tests/multicup.spec.ts
+++ b/tests/multicup.spec.ts
@@ -10,6 +10,7 @@ import {
   backToCupScreen,
   waitForTrackScreen,
   CUSTOM_ICON,
+  useCreationCleanup,
 } from './helpers/mkpc';
 
 // End-to-end coverage of the multicup flow: build a real multicup from scratch
@@ -23,6 +24,7 @@ import {
 //   page 1 -> line  2    -> 2 cups over 1 row
 // Every cup uses a custom (data-uri) icon, so a reset to default icons is
 // detectable.
+const OWNER = 'e2e-mc-bot';
 const NB_CUPS = 6;
 const MULTICUP_OPTIONS = {
   lines: [2, 2, 2],
@@ -39,18 +41,24 @@ test.describe('multicup', () => {
   let mid: number;
   let firstCupId: number;
 
+  // Clears creations left by any earlier run before building this run's fixtures,
+  // and again afterwards so a passing run leaves the database as it found it.
+  // Own owner tag, so a concurrently running spec's cleanup cannot delete these.
+  useCreationCleanup(OWNER);
+
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
     await login(page);
-    const circuitIds = await createCircuits(page.request, 2);
+    const circuitIds = await createCircuits(page.request, 2, OWNER);
     const cupIds: number[] = [];
     for (let i = 0; i < NB_CUPS; i++)
-      cupIds.push(await createCup(page.request, { name: 'e2e-cup-' + (i + 1), circuitIds }));
+      cupIds.push(await createCup(page.request, { name: 'e2e-cup-' + (i + 1), circuitIds, author: OWNER }));
     firstCupId = cupIds[0];
     mid = await createMulticup(page.request, {
       name: 'e2e-multicup',
       cupIds,
       options: MULTICUP_OPTIONS,
+      author: OWNER,
     });
     await page.close();
   });


### PR DESCRIPTION
## Context

The e2e suite creates real data — forum topics, circuits, cups, multicups — and never removed any of it. On my dev database that had accumulated to **19 topics, 171 circuits, 176 cups and 36 multicups**, plus several hundred thousand orphaned notification rows. CI hid the problem because it starts from a fresh database every run, but the suite is not hermetic: a test that assumes "the multicup I just built is the only one" only passes on an empty database.

## What this does

`tests/global-cleanup.ts` runs once before the suite and once after it, wired up as both `globalSetup` and `globalTeardown`. It removes everything in scope — whether this run or an earlier one created it — so an interrupted run is repaired by the next one rather than poisoning it. The after pass is the contract; the before pass is what protects the current run, since a killed run never reaches the after pass, and that is exactly when leftovers get created.

Scope is a **name prefix** (`e2e-%` for creations, the generated title shape for topics) rather than a list of registered owners, so **a new test has nothing to declare centrally** — it only has to name its creations `e2e-*`. Verified by seeding a stray `e2e-orphan-bot` circuit and a stray topic, neither known to any spec: both were gone after the next run.

Supporting pieces: `tests/helpers/db.ts` (a small `sql()` helper over `mysql2` — the DB is already published on `8306` by `docker-compose.yml` in CI and locally, so no reset endpoint is exposed on the site), and `tests/helpers/forum.ts` for the topic cascade. `README.md` documents the `BASE_URL` / `MKPC_DB_*` overrides.

## Design decisions

**Cleanup is global, not per spec.** It began as per-spec `beforeAll`/`afterAll`, which is the wrong place twice over: those hooks run once per *worker*, so a worker finishing early deletes fixtures another worker is still using — reproduced at `--workers=4`, 1 failure in 12 runs — and the only defence is making each spec serial, paying for cleanup with the suite's parallelism. Running once around the whole suite removes both, and also removes the third problem below. Local workers went 3 → 9; CI is unaffected either way, since it already runs `workers: 1`.

**Circuits are deleted through `supprCreation.php`, not SQL.** The endpoint cascades to cups, orphaned multicups, records, ghosts and challenge references, and unlinks the track thumbnail via `postCircuitDelete`. Reproducing that in raw SQL would leak rows and files on every schema change. Cups and multicups whose tracks were already gone are swept afterwards, since the cascade never reaches them.

**Follower notifications are cleaned even though the site never cleans them.** `saveCreation.php`, `saveCup.php`, `saveMCup.php` and `newtopic.php` each insert one `mknotifs` row per follower of the poster, and no deletion path in the site removes them. The seeded Wargor account has 386 followers, so a suite run was burying **5,018 rows** pointing at creations it went on to delete — an order of magnitude more than everything else the cleanup removes, and invisible in CI because `setup.sql` seeds no followers. Measured 5,018 per run before, 0 after.

**Cleanup verifies itself.** Both endpoints report success on failure — `testcode.php` returns `0` on a failed login, and `supprCreation.php` echoes `1` even when it matched no row. Unchecked, a cleanup that silently deleted nothing would leave the suite green while the leak continued, which is the one failure mode that would make this whole PR worthless. The login result is checked and all three creation tables are asserted empty afterwards.

**Forum topics reproduce `supprtopic.php`'s cascade rather than calling it.** Posting a topic also inserts an `mkfollowers` row and bumps `mkprofiles.nbmessages`; deleting only `mktopics`/`mkmessages` leaks the former and inflates the latter by one per run (the dev DB was 29 messages ahead of its real count). `supprtopic.php` is a CSRF-guarded HTML page rather than an API endpoint, so scraping a token to reuse it would be more machinery — and more fragile — than the cascade it replaces. Note that `nbmessages` is `int unsigned`, so the decrement casts to signed first: MariaDB evaluates the subtraction before `GREATEST`, and an underflow is an error, not a negative.

**Cached track previews (`creation_icons/coursepreview*.png`) are deliberately left alone.** `cache_creations.php` self-evicts at `MAX_FILES = 20000`, `setup.sh` already wipes the directory in CI, and in a multi-worktree setup the directory is shared between checkouts — a test deleting from it would reach into another checkout. User-uploaded thumbnails, which are not regenerable, *are* cleaned, by the endpoint above.

## Known limitations

- **Sibling worktrees share one database.** Checkouts get their own web port but the same MariaDB on 8306, and the cleanup scope is a name prefix rather than a checkout, so running the suite in two worktrees simultaneously will cross-clean.
- **The cleanup writes `mklogs` rows it does not remove** — `supprCreation.php` logs each moderator deletion, so a few rows accumulate per run. It is an audit log; deleting from it seemed worse than leaving it.
- The `auteur` columns and `mktopics.titre` are unindexed, so each sweep full-scans those tables. Measured at ~40ms on a prod-sized dev DB, and it now runs twice per suite instead of twice per spec file.

## Unrelated bug noticed while working on this

`supprCreation.php` runs `DELETE c FROM mkmcups c LEFT JOIN mkmcups_tracks t ON c.id=t.mcup WHERE t.mcup IS NULL` — database-wide, ignoring `auteur`. `saveMCup.php` inserts the `mkmcups` row before its `mkmcups_tracks` rows, so a multicup is briefly track-less while being created. Any user deleting a track during that window destroys another user's multicup. Narrow, silent, and not touched by this PR — flagging it as worth its own issue.

## Verification

`13 passed` on repeated runs with all leftover counts at 0 afterwards, from a starting backlog of 19 topics / 171 circuits / 176 cups / 36 multicups. Notification rows per run: 5,018 before, 0 after. Healing verified with fixtures no spec knows about, as described above.
